### PR TITLE
fix: perform action after clean again when sharing identical text

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -157,6 +157,7 @@ dependencies {
     testImplementation(libs.kotest.runner.junit5)
     testImplementation(libs.kotest.assertions.core)
     testImplementation(libs.mockk)
+    testImplementation(libs.kotlinx.coroutines.test)
 
     lintChecks(libs.slack.compose.lint.checks)
 }

--- a/app/src/main/kotlin/com/svenjacobs/app/leon/MainActivity.kt
+++ b/app/src/main/kotlin/com/svenjacobs/app/leon/MainActivity.kt
@@ -33,12 +33,14 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.svenjacobs.app.leon.inject.AppContainer.AppDataStoreManager
 import com.svenjacobs.app.leon.ui.MainRouter
+import com.svenjacobs.app.leon.ui.model.SourceText
 import com.svenjacobs.app.leon.ui.theme.AppTheme
+import java.util.UUID
 import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
 
-    private val sourceText = mutableStateOf<String?>(null)
+    private val sourceText = mutableStateOf<SourceText?>(null)
     private var customTabsInitialized = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -83,12 +85,22 @@ class MainActivity : ComponentActivity() {
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
+        setIntent(intent)
         onIntent(intent)
     }
 
     // TODO: Pass all Intent extras
     private fun onIntent(intent: Intent) {
-        sourceText.value =
+        // The id extra is stamped onto the intent the first time it is seen and stays stable
+        // across activity recreation (e.g. configuration changes), but a new intent (i.e. a new
+        // share) never carries it, so a fresh id is generated. This allows distinguishing "the
+        // same intent redelivered" from "the same text shared again", which must trigger the
+        // configured action after clean again even though the text is unchanged.
+        val id =
+            intent.getStringExtra(EXTRA_SOURCE_TEXT_ID)
+                ?: UUID.randomUUID().toString().also { intent.putExtra(EXTRA_SOURCE_TEXT_ID, it) }
+
+        val text =
             when (intent.action) {
                 Intent.ACTION_SEND ->
                     if (intent.type == MIME_TYPE_TEXT_PLAIN) {
@@ -106,6 +118,8 @@ class MainActivity : ComponentActivity() {
 
                 else -> null
             }
+
+        sourceText.value = SourceText(id = id, text = text)
     }
 
     private fun setupCustomTabsService() {
@@ -133,5 +147,6 @@ class MainActivity : ComponentActivity() {
 
     private companion object {
         private const val MIME_TYPE_TEXT_PLAIN = "text/plain"
+        private const val EXTRA_SOURCE_TEXT_ID = "com.svenjacobs.app.leon.extra.SOURCE_TEXT_ID"
     }
 }

--- a/app/src/main/kotlin/com/svenjacobs/app/leon/ui/MainRouter.kt
+++ b/app/src/main/kotlin/com/svenjacobs/app/leon/ui/MainRouter.kt
@@ -24,13 +24,14 @@ import androidx.lifecycle.compose.dropUnlessResumed
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import com.svenjacobs.app.leon.ui.model.SourceText
 import com.svenjacobs.app.leon.ui.screens.main.MainScreen
 import com.svenjacobs.app.leon.ui.screens.settings.SettingsLicensesScreen
 import com.svenjacobs.app.leon.ui.screens.settings.SettingsSanitizersScreen
 
 @Composable
 fun MainRouter(
-    sourceText: State<String?>,
+    sourceText: State<SourceText?>,
     onResetClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {

--- a/app/src/main/kotlin/com/svenjacobs/app/leon/ui/model/SourceText.kt
+++ b/app/src/main/kotlin/com/svenjacobs/app/leon/ui/model/SourceText.kt
@@ -1,0 +1,29 @@
+/*
+ * Léon - The URL Cleaner
+ * Copyright (C) 2024 Sven Jacobs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.svenjacobs.app.leon.ui.model
+
+import androidx.compose.runtime.Immutable
+
+/**
+ * Text received via an incoming [android.content.Intent], identified by a stable [id].
+ *
+ * The [id] stays the same across activity recreation (e.g. configuration changes) but changes for
+ * every new incoming intent, even if [text] is identical to the previous one. This allows
+ * distinguishing "the same intent redelivered" from "the same text shared again".
+ */
+@Immutable data class SourceText(val id: String, val text: String?)

--- a/app/src/main/kotlin/com/svenjacobs/app/leon/ui/screens/main/MainScreen.kt
+++ b/app/src/main/kotlin/com/svenjacobs/app/leon/ui/screens/main/MainScreen.kt
@@ -96,6 +96,7 @@ import com.svenjacobs.app.leon.R
 import com.svenjacobs.app.leon.core.domain.action.ActionAfterClean
 import com.svenjacobs.app.leon.ui.common.isDefaultBrowser
 import com.svenjacobs.app.leon.ui.common.views.TopAppBar
+import com.svenjacobs.app.leon.ui.model.SourceText
 import com.svenjacobs.app.leon.ui.screens.main.model.MainScreenViewModel
 import com.svenjacobs.app.leon.ui.screens.main.model.MainScreenViewModel.UiState.Result
 import com.svenjacobs.app.leon.ui.screens.main.model.Screen
@@ -108,7 +109,7 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun MainScreen(
-    sourceText: State<String?>,
+    sourceText: State<SourceText?>,
     onNavigateToSettingsSanitizers: () -> Unit,
     onNavigateToSettingsLicenses: () -> Unit,
     onResetClick: () -> Unit,
@@ -127,10 +128,9 @@ fun MainScreen(
     val openTitle = stringResource(R.string.open)
     val copiedToClipboardMessage = stringResource(R.string.clipboard_message)
     val clipboardEmptyMessage = stringResource(R.string.clipboard_empty_message)
-    var didPerformActionAfterClean by remember(uiState.result) { mutableStateOf(false) }
     val view = LocalView.current
 
-    LaunchedEffect(sourceText.value) { viewModel.setText(sourceText.value) }
+    LaunchedEffect(sourceText.value) { sourceText.value?.let { viewModel.setText(it.text, it.id) } }
 
     LaunchedEffect(Unit) {
         val window = view.context.findWindow() ?: return@LaunchedEffect
@@ -200,19 +200,17 @@ fun MainScreen(
 
                 NavHost(navController = navController, startDestination = Screen.Main.route) {
                     composable(Screen.Main.route) {
-                        LaunchedEffect(uiState.result, uiState.actionAfterClean) {
-                            if (didPerformActionAfterClean) return@LaunchedEffect
+                        LaunchedEffect(uiState.inputId, uiState.actionAfterClean) {
+                            val inputId = uiState.inputId ?: return@LaunchedEffect
+                            val result = uiState.result as? Result.Success ?: return@LaunchedEffect
+                            if (!viewModel.consumeActionAfterClean(inputId)) return@LaunchedEffect
 
-                            (uiState.result as? Result.Success)?.let { result ->
-                                when (uiState.actionAfterClean) {
-                                    ActionAfterClean.OpenShareMenu -> openShareMenu(result)
-                                    ActionAfterClean.OpenUrl -> openUrl(result)
-                                    ActionAfterClean.CopyToClipboard ->
-                                        copyToClipboard(result.cleanedText)
-                                    ActionAfterClean.DoNothing -> {}
-                                }
-
-                                didPerformActionAfterClean = true
+                            when (uiState.actionAfterClean) {
+                                ActionAfterClean.OpenShareMenu -> openShareMenu(result)
+                                ActionAfterClean.OpenUrl -> openUrl(result)
+                                ActionAfterClean.CopyToClipboard ->
+                                    copyToClipboard(result.cleanedText)
+                                ActionAfterClean.DoNothing -> {}
                             }
                         }
 

--- a/app/src/main/kotlin/com/svenjacobs/app/leon/ui/screens/main/model/MainScreenViewModel.kt
+++ b/app/src/main/kotlin/com/svenjacobs/app/leon/ui/screens/main/model/MainScreenViewModel.kt
@@ -24,6 +24,7 @@ import com.svenjacobs.app.leon.core.domain.action.ActionAfterClean
 import com.svenjacobs.app.leon.datastore.AppDataStoreManager
 import com.svenjacobs.app.leon.inject.AppContainer.AppDataStoreManager
 import com.svenjacobs.app.leon.ui.screens.main.model.MainScreenViewModel.UiState.Result
+import java.util.UUID
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -38,6 +39,7 @@ class MainScreenViewModel(
 
     data class UiState(
         val isLoading: Boolean = true,
+        val inputId: String? = null,
         val isUrlDecodeEnabled: Boolean = false,
         val isExtractUrlEnabled: Boolean = false,
         val isCustomTabsEnabled: Boolean = false,
@@ -58,27 +60,34 @@ class MainScreenViewModel(
         }
     }
 
-    private val text = MutableStateFlow<String?>(null)
+    /** Text of a single incoming intent, identified by a stable [id]. */
+    private data class Input(val id: String, val text: String)
+
+    private val input = MutableStateFlow<Input?>(null)
+
+    /** Id of the input for which the action after clean has already been performed. */
+    private var handledActionInputId: String? = null
 
     val uiState =
         combine(
-                text,
+                input,
                 appDataStoreManager.urlDecodeEnabled,
                 appDataStoreManager.extractUrlEnabled,
                 appDataStoreManager.customTabsEnabled,
                 appDataStoreManager.actionAfterClean,
-            ) { text, urlDecodeEnabled, extractUrlEnabled, isCustomTabsEnabled, actionAfterClean ->
+            ) { input, urlDecodeEnabled, extractUrlEnabled, isCustomTabsEnabled, actionAfterClean ->
                 val result =
-                    text?.let {
+                    input?.let {
                         clean(
-                            text = text,
+                            text = it.text,
                             decodeUrl = urlDecodeEnabled,
                             extractUrl = extractUrlEnabled,
                         )
                     } ?: Result.Empty
 
                 UiState(
-                    isLoading = text == null,
+                    isLoading = input == null,
+                    inputId = input?.id,
                     isUrlDecodeEnabled = urlDecodeEnabled,
                     isExtractUrlEnabled = extractUrlEnabled,
                     isCustomTabsEnabled = isCustomTabsEnabled,
@@ -92,13 +101,25 @@ class MainScreenViewModel(
                 initialValue = UiState(),
             )
 
-    fun setText(text: String?) {
+    fun setText(text: String?, id: String = UUID.randomUUID().toString()) {
         if (text == null && uiState.value.result is Result.Success) return
-        this.text.value = text
+        input.value = text?.let { Input(id = id, text = it) }
     }
 
     fun onResetClick() {
-        text.value = null
+        input.value = null
+    }
+
+    /**
+     * Returns `true` if the action after clean configured by the user still needs to be performed
+     * for [inputId] and marks it as handled. Returns `false` if it was already performed for this
+     * exact input, which happens when the UI recomposes or the activity is recreated (e.g. on a
+     * configuration change) without a genuinely new input being submitted.
+     */
+    fun consumeActionAfterClean(inputId: String): Boolean {
+        if (inputId == handledActionInputId) return false
+        handledActionInputId = inputId
+        return true
     }
 
     fun onUrlDecodeCheckedChange(enabled: Boolean) {

--- a/app/src/test/kotlin/com/svenjacobs/app/leon/ui/screens/main/model/MainScreenViewModelTest.kt
+++ b/app/src/test/kotlin/com/svenjacobs/app/leon/ui/screens/main/model/MainScreenViewModelTest.kt
@@ -1,0 +1,108 @@
+/*
+ * Léon - The URL Cleaner
+ * Copyright (C) 2026 Sven Jacobs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.svenjacobs.app.leon.ui.screens.main.model
+
+import com.svenjacobs.app.leon.core.domain.CleanerService
+import com.svenjacobs.app.leon.core.domain.action.ActionAfterClean
+import com.svenjacobs.app.leon.datastore.AppDataStoreManager
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainScreenViewModelTest :
+    WordSpec({
+        lateinit var viewModel: MainScreenViewModel
+
+        beforeEach {
+            Dispatchers.setMain(UnconfinedTestDispatcher())
+
+            val appDataStoreManager =
+                mockk<AppDataStoreManager> {
+                    every { urlDecodeEnabled } returns flowOf(false)
+                    every { extractUrlEnabled } returns flowOf(false)
+                    every { customTabsEnabled } returns flowOf(false)
+                    every { actionAfterClean } returns flowOf(ActionAfterClean.OpenShareMenu)
+                }
+
+            val cleanerService =
+                mockk<CleanerService> {
+                    coEvery { clean(any(), any()) } answers
+                        {
+                            val text = firstArg<String>()
+                            CleanerService.Result(
+                                originalText = text,
+                                cleanedText = text,
+                                urls = persistentListOf(text),
+                            )
+                        }
+                }
+
+            viewModel =
+                MainScreenViewModel(
+                    appDataStoreManager = appDataStoreManager,
+                    cleanerService = cleanerService,
+                )
+        }
+
+        afterEach { Dispatchers.resetMain() }
+
+        "setText" should
+            {
+                "assign a different inputId when the same text is submitted twice" {
+                    runTest(UnconfinedTestDispatcher()) {
+                        backgroundScope.launch { viewModel.uiState.collect {} }
+
+                        viewModel.setText("https://example.com")
+                        val firstId = viewModel.uiState.value.inputId
+
+                        viewModel.setText("https://example.com")
+                        val secondId = viewModel.uiState.value.inputId
+
+                        firstId shouldNotBe null
+                        secondId shouldNotBe null
+                        secondId shouldNotBe firstId
+                    }
+                }
+            }
+
+        "consumeActionAfterClean" should
+            {
+                "return true on first call and false on a repeated call for the same inputId" {
+                    viewModel.consumeActionAfterClean("id-1") shouldBe true
+                    viewModel.consumeActionAfterClean("id-1") shouldBe false
+                }
+
+                "return true again for a new inputId, even with identical text (#775)" {
+                    viewModel.consumeActionAfterClean("id-1") shouldBe true
+                    viewModel.consumeActionAfterClean("id-2") shouldBe true
+                }
+            }
+    })

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,6 +41,7 @@ kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", v
 kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8" }
 kotlinx-collections-immutable = "org.jetbrains.kotlinx:kotlinx-collections-immutable:0.4.0"
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinx-coroutines" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 kotlinx-serialization-json = "org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0"
 mikepenz-aboutlibraries-compose-m3 = { module = "com.mikepenz:aboutlibraries-compose-m3", version.ref = "mikepenz-aboutlibraries" }
 mockk = "io.mockk:mockk:1.14.9"


### PR DESCRIPTION
## Summary
- Sharing the exact same text/URL twice while Léon is already running was silently swallowed by value-equality checks all along the intent → state → StateFlow → composition chain, so the configured "action after clean" (e.g. opening the share menu) only fired once per distinct string.
- Each incoming `Intent` is now tagged with an id that is stable across activity recreation (e.g. configuration changes) but changes for every genuinely new intent, and the "already performed" bookkeeping moved from the Compose `remember` into `MainScreenViewModel` so it also survives configuration changes without re-firing the action.
- Also fixes a related defect where rotating the device while a result was on screen re-triggered the action after clean.

Fixes #775

## Root cause (verified by reproduction on-device)
1. `MainActivity` held `sourceText` as `mutableStateOf<String?>`, so assigning the same string on a repeat share triggered no recomposition.
2. `MainScreen`'s `LaunchedEffect(sourceText.value)` was keyed on the value, so it wouldn't relaunch either.
3. `MainScreenViewModel`'s internal `MutableStateFlow<String?>` doesn't re-emit an equal value.
4. `remember(uiState.result)` / `LaunchedEffect(uiState.result, …)` in `MainScreen` keyed on the `Result.Success` data class, which was structurally equal for a repeat.

`launchMode="singleTask"` keeps the process alive across shares, so all four gates held — which is why killing the app "fixed" it.

## Test plan
- [x] `./gradlew :app:testDebugUnitTest` — new `MainScreenViewModelTest` covers: distinct ids for identical text, one-shot `consumeActionAfterClean` semantics, and the #775 regression (new id ⇒ action fires again for identical text)
- [x] `./gradlew spotlessCheck lintDebug`
- [x] Manual verification on emulator (API 36) with *Action after clean = Open share menu*: repeat-sharing the identical URL now reopens the share sheet every time; rotating with a result on screen no longer re-opens it; distinct URLs and normal navigation are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)