### PR TITLE
fix(sanitizer): keep the article reference of Substack URLs

### DIFF
--- a/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/substack/SubstackSanitizer.kt
+++ b/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/substack/SubstackSanitizer.kt
@@ -33,6 +33,8 @@ import com.svenjacobs.app.leon.core.domain.sanitizer.SanitizerId
  *   leaves a URL that no longer points to any article at all, so those two are kept.
  * - `open.substack.com/pub/<publication>/p/<slug>` URLs are an indirection for opening the article
  *   in the Substack app. They are rewritten to the canonical `<publication>.substack.com/p/<slug>`.
+ * - `substack.com/redirect/<uuid>?j=<blob>` URLs are left untouched. It is not publicly documented
+ *   what the `j` blob carries, and removing it would leave a dead link.
  *
  * For all other Substack URLs the path already is the article reference, so only the parameters are
  * removed. The fragment is always kept since it references a section or comment of the article.
@@ -53,6 +55,8 @@ class SubstackSanitizer : Sanitizer {
         val path = groupValues[3]
         val query = groupValues[4]
         val fragment = groupValues[5]
+
+        if (REDIRECT_PATH_REGEX.matches(path)) return input
 
         val (cleanedHost, cleanedPath) = canonicalize(host, path)
         val cleanedQuery =
@@ -76,7 +80,13 @@ class SubstackSanitizer : Sanitizer {
         return Pair("${groupValues[1]}.substack.com", groupValues[2])
     }
 
-    /** Removes all parameters of [query] except those named in [parameters], preserving order. */
+    /**
+     * Removes all parameters of [query] except those named in [parameters], preserving order.
+     *
+     * `RegexFactory.exceptParameter` is the obvious helper for this but cannot be used here: its
+     * `[^&]+` swallows the fragment along with the last parameter, and the fragment is exactly what
+     * this sanitizer preserves.
+     */
     private fun keepParameters(query: String, parameters: Set<String>): String {
         val kept =
             query.removePrefix("?").split('&').filter { it.substringBefore('=') in parameters }
@@ -92,21 +102,23 @@ class SubstackSanitizer : Sanitizer {
          * Matches Substack URLs, capturing scheme, host, path, parameters and fragment.
          *
          * The path has to start with `/` so that the host ends at `substack.com` and a URL like
-         * `https://substack.com.example.com/p/foo` does not match.
+         * `https://substack.com.example.com/p/foo` does not match. An optional port is part of the
+         * host group so that it survives into the result.
          */
         private val URL_REGEX =
             Regex(
-                "(https?://)?((?:[A-Za-z0-9-]+\\.)*substack\\.com)((?:/[^?#]*)?)(\\?[^#]*)?(#.*)?",
+                "(https?://)?((?:[A-Za-z0-9-]+\\.)*substack\\.com(?::\\d+)?)((?:/[^?#]*)?)(\\?[^#]*)?(#.*)?",
                 RegexOption.IGNORE_CASE,
             )
 
         private val APP_LINK_PATH_REGEX = Regex("/app-link(/.*)?", RegexOption.IGNORE_CASE)
 
+        private val REDIRECT_PATH_REGEX = Regex("/redirect(/.*)?", RegexOption.IGNORE_CASE)
+
         private val OPEN_PUB_PATH_REGEX =
             Regex("/pub/([A-Za-z0-9-]+)(/.*)?", RegexOption.IGNORE_CASE)
 
         /** Parameters of `app-link` URLs which reference the actual content. */
-        private val APP_LINK_REFERENCE_PARAMETERS =
-            setOf("publication_id", "post_id", "note_id", "comment_id")
+        private val APP_LINK_REFERENCE_PARAMETERS = setOf("publication_id", "post_id", "note_id")
     }
 }

--- a/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/substack/SubstackSanitizer.kt
+++ b/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/substack/SubstackSanitizer.kt
@@ -18,20 +18,95 @@
 package com.svenjacobs.app.leon.core.domain.sanitizer.substack
 
 import android.content.Context
-import com.svenjacobs.app.leon.core.common.domain.matchesDomainRegex
-import com.svenjacobs.app.leon.core.common.regex.RegexFactory
 import com.svenjacobs.app.leon.core.domain.R
-import com.svenjacobs.app.leon.core.domain.sanitizer.RegexSanitizer
 import com.svenjacobs.app.leon.core.domain.sanitizer.Sanitizer
 import com.svenjacobs.app.leon.core.domain.sanitizer.SanitizerId
 
-class SubstackSanitizer : RegexSanitizer(regex = RegexFactory.AllParameters) {
+/**
+ * Reduces Substack URLs to the reference of the article (or note, comment …) they point to.
+ *
+ * Substack appends a lot of tracking to links inside newsletter emails, most notably `r` (the
+ * reader who received the mail) and `token` (a JWT identifying that reader), next to the usual
+ * `utm_*` campaign parameters. Removing all parameters is not enough though:
+ * - `substack.com/app-link/…` URLs, which are used for the links inside newsletter mails, carry the
+ *   article reference in the `publication_id` and `post_id` parameters. Dropping all parameters
+ *   leaves a URL that no longer points to any article at all, so those two are kept.
+ * - `open.substack.com/pub/<publication>/p/<slug>` URLs are an indirection for opening the article
+ *   in the Substack app. They are rewritten to the canonical `<publication>.substack.com/p/<slug>`.
+ *
+ * For all other Substack URLs the path already is the article reference, so only the parameters are
+ * removed. The fragment is always kept since it references a section or comment of the article.
+ */
+class SubstackSanitizer : Sanitizer {
 
     override val id = SanitizerId("substack")
 
     override fun getMetadata(context: Context) =
         Sanitizer.Metadata(name = context.getString(R.string.sanitizer_substack))
 
-    override fun matchesDomain(input: String) =
-        input.matchesDomainRegex(domain = "(open\\.)?substack\\.com")
+    override fun matchesDomain(input: String) = URL_REGEX.matches(input)
+
+    override fun invoke(input: String): String {
+        val groupValues = URL_REGEX.matchEntire(input)?.groupValues ?: return input
+        val scheme = groupValues[1]
+        val host = groupValues[2]
+        val path = groupValues[3]
+        val query = groupValues[4]
+        val fragment = groupValues[5]
+
+        val (cleanedHost, cleanedPath) = canonicalize(host, path)
+        val cleanedQuery =
+            if (APP_LINK_PATH_REGEX.matches(cleanedPath)) {
+                keepParameters(query, APP_LINK_REFERENCE_PARAMETERS)
+            } else {
+                ""
+            }
+
+        return "$scheme$cleanedHost$cleanedPath$cleanedQuery$fragment"
+    }
+
+    /**
+     * Rewrites the `open.substack.com/pub/<publication>` indirection to the canonical
+     * `<publication>.substack.com` host, keeping the remaining path.
+     */
+    private fun canonicalize(host: String, path: String): Pair<String, String> {
+        if (!host.equals(OPEN_HOST, ignoreCase = true)) return Pair(host, path)
+        val groupValues =
+            OPEN_PUB_PATH_REGEX.matchEntire(path)?.groupValues ?: return Pair(host, path)
+        return Pair("${groupValues[1]}.substack.com", groupValues[2])
+    }
+
+    /** Removes all parameters of [query] except those named in [parameters], preserving order. */
+    private fun keepParameters(query: String, parameters: Set<String>): String {
+        val kept =
+            query.removePrefix("?").split('&').filter { it.substringBefore('=') in parameters }
+
+        return if (kept.isEmpty()) "" else "?${kept.joinToString("&")}"
+    }
+
+    private companion object {
+
+        private const val OPEN_HOST = "open.substack.com"
+
+        /**
+         * Matches Substack URLs, capturing scheme, host, path, parameters and fragment.
+         *
+         * The path has to start with `/` so that the host ends at `substack.com` and a URL like
+         * `https://substack.com.example.com/p/foo` does not match.
+         */
+        private val URL_REGEX =
+            Regex(
+                "(https?://)?((?:[A-Za-z0-9-]+\\.)*substack\\.com)((?:/[^?#]*)?)(\\?[^#]*)?(#.*)?",
+                RegexOption.IGNORE_CASE,
+            )
+
+        private val APP_LINK_PATH_REGEX = Regex("/app-link(/.*)?", RegexOption.IGNORE_CASE)
+
+        private val OPEN_PUB_PATH_REGEX =
+            Regex("/pub/([A-Za-z0-9-]+)(/.*)?", RegexOption.IGNORE_CASE)
+
+        /** Parameters of `app-link` URLs which reference the actual content. */
+        private val APP_LINK_REFERENCE_PARAMETERS =
+            setOf("publication_id", "post_id", "note_id", "comment_id")
+    }
 }

--- a/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/substack/SubstackSanitizerTest.kt
+++ b/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/substack/SubstackSanitizerTest.kt
@@ -89,6 +89,16 @@ class SubstackSanitizerTest :
                     ) shouldBe "https://substack.com/app-link/post"
                 }
 
+                "leave redirect links untouched" {
+                    sanitizer("https://substack.com/redirect/2f9a1c/?j=eyJ1IjoiYWJjIn0") shouldBe
+                        "https://substack.com/redirect/2f9a1c/?j=eyJ1IjoiYWJjIn0"
+                }
+
+                "keep a port while removing parameters" {
+                    sanitizer("https://substack.com:443/p/some-article?r=c0obe") shouldBe
+                        "https://substack.com:443/p/some-article"
+                }
+
                 "leave an already clean URL untouched" {
                     sanitizer(
                         "https://fosspost.substack.com/p/open-up-your-android-smartphone"
@@ -116,6 +126,10 @@ class SubstackSanitizerTest :
 
                 "match publication subdomains" {
                     sanitizer.matchesDomain("https://fosspost.substack.com/p/article") shouldBe true
+                }
+
+                "match hosts with a port" {
+                    sanitizer.matchesDomain("https://substack.com:443/p/article") shouldBe true
                 }
 
                 "not match domains which merely end with substack.com" {

--- a/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/substack/SubstackSanitizerTest.kt
+++ b/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/substack/SubstackSanitizerTest.kt
@@ -32,11 +32,75 @@ class SubstackSanitizerTest :
                     ) shouldBe "https://substack.com/@sebastianbarros/note/c-190523061"
                 }
 
-                "remove parameters from open.substack.com" {
+                "remove parameters from publication subdomains" {
+                    sanitizer(
+                        "https://fosspost.substack.com/p/open-up-your-android-smartphone?r=c0obe&utm_campaign=email-post&utm_medium=email&triedRedirect=true"
+                    ) shouldBe "https://fosspost.substack.com/p/open-up-your-android-smartphone"
+                }
+
+                "keep the fragment which references a section or comment" {
+                    sanitizer(
+                        "https://fosspost.substack.com/p/open-up-your-android-smartphone?r=c0obe#comment-12345"
+                    ) shouldBe
+                        "https://fosspost.substack.com/p/open-up-your-android-smartphone#comment-12345"
+                }
+
+                "rewrite open.substack.com to the publication of the article" {
                     sanitizer(
                         "https://open.substack.com/pub/fosspost/p/open-up-your-android-smartphone?utm_campaign=post-expanded-share&utm_medium=web"
+                    ) shouldBe "https://fosspost.substack.com/p/open-up-your-android-smartphone"
+                }
+
+                "rewrite open.substack.com of a newsletter mail" {
+                    sanitizer(
+                        "https://open.substack.com/pub/presspublish/p/practical-customising-your-substack-3f7?r=20ql4m&showWelcomeOnShare=true&triedRedirect=true"
                     ) shouldBe
-                        "https://open.substack.com/pub/fosspost/p/open-up-your-android-smartphone"
+                        "https://presspublish.substack.com/p/practical-customising-your-substack-3f7"
+                }
+
+                "rewrite open.substack.com without an article" {
+                    sanitizer("https://open.substack.com/pub/fosspost") shouldBe
+                        "https://fosspost.substack.com"
+                }
+
+                "keep the article reference of app-link URLs of a newsletter mail" {
+                    sanitizer(
+                        "https://substack.com/app-link/post?publication_id=162759&post_id=178435284&utm_campaign=email-post-title&isFreemail=true&r=c0obe&token=eyJ1c2VyX2lkIjoxfQ&utm_medium=email&triedRedirect=true"
+                    ) shouldBe
+                        "https://substack.com/app-link/post?publication_id=162759&post_id=178435284"
+                }
+
+                "keep the article reference of app-link URLs shared from the app" {
+                    sanitizer(
+                        "https://substack.com/app-link/post?publication_id=89120&post_id=209203336&action=share&triggerShare=true&isFreemail=true&r=1a2b3c&token=eyJzdWIiOiJwb3N0LXJlYWN0aW9uIn0.c2lnbmF0dXJl"
+                    ) shouldBe
+                        "https://substack.com/app-link/post?publication_id=89120&post_id=209203336"
+                }
+
+                "keep the note reference of app-link URLs" {
+                    sanitizer(
+                        "https://substack.com/app-link/note?note_id=c-190523061&r=c0obe&token=eyJhIjoxfQ"
+                    ) shouldBe "https://substack.com/app-link/note?note_id=c-190523061"
+                }
+
+                "not leave an empty query when an app-link URL has no reference" {
+                    sanitizer(
+                        "https://substack.com/app-link/post?token=eyJ1c2VyX2lkIjoxfQ&r=c0obe"
+                    ) shouldBe "https://substack.com/app-link/post"
+                }
+
+                "leave an already clean URL untouched" {
+                    sanitizer(
+                        "https://fosspost.substack.com/p/open-up-your-android-smartphone"
+                    ) shouldBe "https://fosspost.substack.com/p/open-up-your-android-smartphone"
+                }
+
+                "be idempotent" {
+                    val once =
+                        sanitizer(
+                            "https://open.substack.com/pub/fosspost/p/open-up-your-android-smartphone?r=c0obe"
+                        )
+                    sanitizer(once) shouldBe once
                 }
             }
 
@@ -48,6 +112,19 @@ class SubstackSanitizerTest :
 
                 "match open.substack.com" {
                     sanitizer.matchesDomain("https://open.substack.com") shouldBe true
+                }
+
+                "match publication subdomains" {
+                    sanitizer.matchesDomain("https://fosspost.substack.com/p/article") shouldBe true
+                }
+
+                "not match domains which merely end with substack.com" {
+                    sanitizer.matchesDomain("https://notsubstack.com/p/article") shouldBe false
+                }
+
+                "not match domains which merely start with substack.com" {
+                    sanitizer.matchesDomain("https://substack.com.example.com/p/article") shouldBe
+                        false
                 }
             }
     })


### PR DESCRIPTION
## TL;DR

Substack puts the article reference into the query string of `app-link` URLs, so removing all
parameters left links that no longer pointed at any article. The sanitizer now keeps
`publication_id`/`post_id`, matches every `*.substack.com` host instead of only `substack.com` and
`open.substack.com`, and rewrites the `open.substack.com/pub/<publication>` indirection to the
canonical publication URL.

## Notable decisions

* The fragment is now kept, since it references a section or comment of the article. Previously it
  was removed whenever the URL also had parameters, because `RegexFactory.AllParameters` matches
  everything from `?` onwards.
* The host is matched more strictly than `matchesDomainRegex` does: the path has to start with `/`,
  so `https://substack.com.example.com/p/foo` no longer matches. That mattered less while the
  sanitizer only trimmed parameters, but this one also rewrites the host.
* `substack.com/redirect/<uuid>?j=<blob>` links are deliberately left as they were. It is not
  publicly documented whether the `j` blob carries the destination or only the recipient, so
  dropping it stays the existing behaviour rather than a new assumption.
* A cleaned `app-link` URL stays opaque, because Substack only resolves it to the readable slug via
  a redirect and the app makes no network requests.

## Testing

1. Share `https://substack.com/app-link/post?publication_id=89120&post_id=209203336&isFreemail=true&r=<reader>&token=<jwt>`
   with Léon. The cleaned URL must be
   `https://substack.com/app-link/post?publication_id=89120&post_id=209203336` and must still open
   the article.
2. Share `https://open.substack.com/pub/fosspost/p/some-article?r=abc&triedRedirect=true`. The
   cleaned URL must be `https://fosspost.substack.com/p/some-article`.
3. Share `https://fosspost.substack.com/p/some-article?r=abc#comment-1`. The `r` parameter must be
   gone while `#comment-1` is kept.
4. Run `./gradlew :core-domain:test`.

---

This is my first open source contribution, so please say directly if anything here doesn't match
how you'd want it done. I use Léon every day, mostly on newsletter links, which is how I ran into
this — thanks for building and maintaining it.

The `bug` label applies, but I can't set labels from a fork.
