### PR TITLE
fix(sanitizer): remove Instagram "igsi" parameter

### DIFF
--- a/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/instagram/InstagramSanitizer.kt
+++ b/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/instagram/InstagramSanitizer.kt
@@ -25,7 +25,7 @@ import com.svenjacobs.app.leon.core.domain.sanitizer.RegexSanitizer
 import com.svenjacobs.app.leon.core.domain.sanitizer.Sanitizer
 import com.svenjacobs.app.leon.core.domain.sanitizer.SanitizerId
 
-class InstagramSanitizer : RegexSanitizer(regex = RegexFactory.ofParameter("igsh")) {
+class InstagramSanitizer : RegexSanitizer(regex = RegexFactory.ofParameter("igsh|igsi")) {
 
     override val id = SanitizerId("instagram")
 

--- a/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/instagram/InstagramSanitizerTest.kt
+++ b/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/instagram/InstagramSanitizerTest.kt
@@ -22,15 +22,42 @@ import io.kotest.matchers.shouldBe
 
 class InstagramSanitizerTest :
     WordSpec({
+        val sanitizer = InstagramSanitizer()
+
         "invoke" should
             {
-                "remove \"igshid\" parameter" {
-                    val sanitizer = InstagramSanitizer()
-
+                "remove \"igsh\" parameter" {
                     val result =
                         sanitizer("https://www.instagram.com/reel/Ceeg-VgI4yF/?igsh=YmMyMTA2M2Y=")
 
                     result shouldBe "https://www.instagram.com/reel/Ceeg-VgI4yF/"
+                }
+
+                "remove \"igsi\" parameter" {
+                    val result =
+                        sanitizer("https://www.instagram.com/reel/Ceeg-VgI4yF/?igsi=YmMyMTA2M2Y=")
+
+                    result shouldBe "https://www.instagram.com/reel/Ceeg-VgI4yF/"
+                }
+
+                "keep other parameters" {
+                    val result =
+                        sanitizer("https://www.instagram.com/p/Ceeg-VgI4yF/?igsi=abc&img_index=2")
+
+                    result shouldBe "https://www.instagram.com/p/Ceeg-VgI4yF/&img_index=2"
+                }
+            }
+
+        "matchesDomain" should
+            {
+                "match instagram.com" {
+                    sanitizer.matchesDomain("https://www.instagram.com/reel/Ceeg-VgI4yF/") shouldBe
+                        true
+                }
+
+                "not match other.com" {
+                    sanitizer.matchesDomain("https://www.other.com/reel/Ceeg-VgI4yF/") shouldBe
+                        false
                 }
             }
     })


### PR DESCRIPTION
## TL;DR

Instagram started appending an `igsi=` code to shared links, which the cleaner passed through untouched. The Instagram sanitizer now removes `igsi` alongside `igsh`.

Closes #788

## Testing

1. Share `https://www.instagram.com/reel/Ceeg-VgI4yF/?igsi=YmMyMTA2M2Y=` with Léon.
2. The cleaned URL must be `https://www.instagram.com/reel/Ceeg-VgI4yF/`.
3. Run `./gradlew :core-domain:test`.