### PR TITLE
fix(sanitizer): match domains against the complete host

### DIFF
--- a/core-common/src/main/kotlin/com/svenjacobs/app/leon/core/common/domain/DomainExtensions.kt
+++ b/core-common/src/main/kotlin/com/svenjacobs/app/leon/core/common/domain/DomainExtensions.kt
@@ -17,10 +17,52 @@
  */
 package com.svenjacobs.app.leon.core.common.domain
 
-fun String.matchesDomainRegex(domain: String): Boolean =
-    Regex("^(?:https?://)?(?:www\\.)?$domain.*").matches(this)
+private val SCHEME = Regex("^https?://")
 
-fun String.matchesDomain(domain: String): Boolean = matchesDomainRegex(domain.replace(".", "\\."))
+private val HOST_DELIMITERS = charArrayOf(':', '/', '?', '#')
 
+/**
+ * Returns whether this URL is matched by the regular expression [domain].
+ *
+ * An optional scheme and an optional leading `www.` are matched implicitly, so `example\.com`
+ * matches `example.com`, `http://example.com` and `https://www.example.com` alike.
+ *
+ * [domain] must cover the complete host of the URL. A pattern which merely is a prefix of the host
+ * does *not* match, which keeps lookalike hosts such as `example.com.evil.com` or
+ * `example.computer` from being treated as `example.com`. Whatever follows the host — a port, a
+ * path, a query or a fragment — is not restricted, and [domain] may reach into the path itself, for
+ * example `google\.com/maps`.
+ *
+ * @param domain Regular expression of the domain, without scheme and without leading `www.`
+ */
+fun String.matchesDomainRegex(domain: String): Boolean {
+    val match = Regex("^(?:https?://)?(?:www\\.)?(?:$domain)").find(this) ?: return false
+    return match.range.last + 1 >= hostEndIndex()
+}
+
+/**
+ * Returns whether this URL is hosted at exactly [domain].
+ *
+ * @param domain Literal domain, without scheme and without leading `www.`
+ */
+fun String.matchesDomain(domain: String): Boolean = matchesDomainRegex(domain.quoteDots())
+
+/**
+ * Returns whether this URL is hosted at [domain] or at any of its subdomains.
+ *
+ * @param domain Literal domain, without scheme and without leading `www.`
+ */
 fun String.matchesSubdomains(domain: String): Boolean =
-    Regex("^(?:https?://)?.*$domain.*").matches(this)
+    matchesDomainRegex("(?:[^./?#:]+\\.)*${domain.quoteDots()}")
+
+private fun String.quoteDots(): String = replace(".", "\\.")
+
+/**
+ * Returns the index at which the host of this URL ends, which is the first delimiter after an
+ * optional scheme, or the length of the string when there is none.
+ */
+private fun String.hostEndIndex(): Int {
+    val start = SCHEME.find(this)?.value?.length ?: 0
+    val index = indexOfAny(HOST_DELIMITERS, startIndex = start)
+    return if (index == -1) length else index
+}

--- a/core-common/src/test/kotlin/com/svenjacobs/app/leon/core/common/domain/DomainExtensionsTest.kt
+++ b/core-common/src/test/kotlin/com/svenjacobs/app/leon/core/common/domain/DomainExtensionsTest.kt
@@ -42,6 +42,15 @@ class DomainExtensionsTest :
                     "www.some.example.com".matchesDomain("some.example.com") shouldBe true
                 }
 
+                "match domain with port" {
+                    "https://example.com:8443/path?a=1".matchesDomain("example.com") shouldBe true
+                }
+
+                "match domain with query and fragment" {
+                    "https://example.com?a=1".matchesDomain("example.com") shouldBe true
+                    "https://example.com#top".matchesDomain("example.com") shouldBe true
+                }
+
                 "match domain with regular expression values" {
                     "https://aliexpress.com/item/32948511896"
                         .matchesDomainRegex(domain = "aliexpress\\..+/item/") shouldBe true
@@ -51,9 +60,36 @@ class DomainExtensionsTest :
                     "other.example.com".matchesDomain("some.example.com") shouldBe false
                 }
 
+                "not match host which only starts with domain" {
+                    "https://example.com.evil.com/path".matchesDomain("example.com") shouldBe false
+                    "https://example.com.evil.com:443/p".matchesDomain("example.com") shouldBe false
+                    "https://example.computer/path".matchesDomain("example.com") shouldBe false
+                    "https://example.com-evil.com".matchesDomain("example.com") shouldBe false
+                }
+
+                "not match domain in user information" {
+                    "https://example.com@evil.com/path".matchesDomain("example.com") shouldBe false
+                }
+
+                "not match subdomain of domain" {
+                    "https://sub.example.com".matchesDomain("example.com") shouldBe false
+                }
+
                 "match subdomains" {
                     "sub.example.com".matchesSubdomains("example.com") shouldBe true
                     "sub.example2.com".matchesSubdomains("example.com") shouldBe false
+                }
+
+                "match domain itself and nested subdomains" {
+                    "https://example.com/path".matchesSubdomains("example.com") shouldBe true
+                    "https://a.b.example.com".matchesSubdomains("example.com") shouldBe true
+                }
+
+                "not match lookalike host of subdomains" {
+                    "https://example.com.evil.com".matchesSubdomains("example.com") shouldBe false
+                    "https://notexample.com".matchesSubdomains("example.com") shouldBe false
+                    "https://evil.com/?u=example.com".matchesSubdomains("example.com") shouldBe
+                        false
                 }
             }
     })

--- a/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/aliexpress/AliexpressSanitizer.kt
+++ b/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/aliexpress/AliexpressSanitizer.kt
@@ -33,5 +33,5 @@ class AliexpressSanitizer : RegexSanitizer(regex = RegexFactory.AllParameters) {
         Sanitizer.Metadata(name = context.getString(R.string.sanitizer_aliexpress_name))
 
     override fun matchesDomain(input: String) =
-        input.matchesDomainRegex("(.+\\.)?aliexpress\\..+/item/")
+        input.matchesDomainRegex("(?:[^./?#:]+\\.)*aliexpress\\.[^./?#:]+/item/")
 }

--- a/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/amazon/AmazonProductSanitizer.kt
+++ b/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/amazon/AmazonProductSanitizer.kt
@@ -43,6 +43,6 @@ class AmazonProductSanitizer : Sanitizer {
 
     private companion object {
         private val REGEX =
-            Regex("((?:https?://)?(?:www\\.)?amazon\\.[^/]*).*/(?:dp?|gp/product)?/([^/?&]*)")
+            Regex("^((?:https?://)?(?:www\\.)?amazon\\.[^/?#]*).*/(?:dp?|gp/product)?/([^/?&]*)")
     }
 }

--- a/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/amazon/AmazonSanitizer.kt
+++ b/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/amazon/AmazonSanitizer.kt
@@ -36,5 +36,5 @@ class AmazonSanitizer : RegexSanitizer(regex = RegexFactory.ofParameter("ref_?")
     override fun getMetadata(context: Context) =
         Sanitizer.Metadata(name = context.getString(R.string.sanitizer_amazon_name))
 
-    override fun matchesDomain(input: String) = input.matchesDomainRegex("amazon\\..+/")
+    override fun matchesDomain(input: String) = input.matchesDomainRegex("amazon\\.[^/?#:]+/")
 }

--- a/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/ebay/EbaySanitizer.kt
+++ b/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/ebay/EbaySanitizer.kt
@@ -32,5 +32,5 @@ class EbaySanitizer : RegexSanitizer(regex = RegexFactory.AllParameters) {
     override fun getMetadata(context: Context) =
         Sanitizer.Metadata(name = context.getString(R.string.sanitizer_ebay_name))
 
-    override fun matchesDomain(input: String) = input.matchesDomainRegex("ebay\\..+/itm/")
+    override fun matchesDomain(input: String) = input.matchesDomainRegex("ebay\\.[^/?#:]+/itm/")
 }

--- a/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/facebook/FacebookSanitizer.kt
+++ b/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/facebook/FacebookSanitizer.kt
@@ -33,5 +33,5 @@ class FacebookSanitizer : RegexSanitizer(regex = RegexFactory.exceptParameter("(
         Sanitizer.Metadata(name = context.getString(R.string.sanitizer_facebook_name))
 
     override fun matchesDomain(input: String) =
-        input.matchesDomainRegex(domain = "(m\\.)?facebook.com")
+        input.matchesDomainRegex(domain = "(m\\.)?facebook\\.com")
 }

--- a/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/flipkart/FlipkartSanitizer.kt
+++ b/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/flipkart/FlipkartSanitizer.kt
@@ -18,7 +18,7 @@
 package com.svenjacobs.app.leon.core.domain.sanitizer.flipkart
 
 import android.content.Context
-import com.svenjacobs.app.leon.core.common.domain.matchesDomainRegex
+import com.svenjacobs.app.leon.core.common.domain.matchesSubdomains
 import com.svenjacobs.app.leon.core.common.regex.RegexFactory
 import com.svenjacobs.app.leon.core.domain.R
 import com.svenjacobs.app.leon.core.domain.sanitizer.RegexSanitizer
@@ -32,5 +32,5 @@ class FlipkartSanitizer : RegexSanitizer(regex = RegexFactory.AllParameters) {
     override fun getMetadata(context: Context) =
         Sanitizer.Metadata(name = context.getString(R.string.sanitizer_flipkart_name))
 
-    override fun matchesDomain(input: String) = input.matchesDomainRegex(".*\\.flipkart\\.com")
+    override fun matchesDomain(input: String) = input.matchesSubdomains("flipkart.com")
 }

--- a/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/georiot/GeoRiotSanitizer.kt
+++ b/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/georiot/GeoRiotSanitizer.kt
@@ -33,5 +33,5 @@ class GeoRiotSanitizer : SearchResultSanitizer(RegexFactory.ofParameter("GR_URL"
         Sanitizer.Metadata(name = context.getString(R.string.sanitizer_georiot_name))
 
     override fun matchesDomain(input: String) =
-        input.matchesDomainRegex("target.georiot\\.[^/]+/Proxy.ashx")
+        input.matchesDomainRegex("target\\.georiot\\.[^/?#:]+/Proxy\\.ashx")
 }

--- a/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/google/GoogleSearchSanitizer.kt
+++ b/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/google/GoogleSearchSanitizer.kt
@@ -32,5 +32,5 @@ class GoogleSearchSanitizer : SearchResultSanitizer(RegexFactory.ofParameter("ur
     override fun getMetadata(context: Context) =
         Sanitizer.Metadata(name = context.getString(R.string.sanitizer_google_search_name))
 
-    override fun matchesDomain(input: String) = input.matchesDomainRegex("google\\.[^/]+/url")
+    override fun matchesDomain(input: String) = input.matchesDomainRegex("google\\.[^/?#:]+/url")
 }

--- a/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/linksynergy/LinkSynergySanitizer.kt
+++ b/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/linksynergy/LinkSynergySanitizer.kt
@@ -32,5 +32,6 @@ class LinkSynergySanitizer : SearchResultSanitizer(RegexFactory.ofParameter("mur
     override fun getMetadata(context: Context) =
         Sanitizer.Metadata(name = context.getString(R.string.sanitizer_linksynergy_name))
 
-    override fun matchesDomain(input: String) = input.matchesDomainRegex("linksynergy\\.[^/]+/link")
+    override fun matchesDomain(input: String) =
+        input.matchesDomainRegex("(?:[^./?#:]+\\.)*linksynergy\\.[^/?#:]+/link")
 }

--- a/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/mydealz/MyDealzDomains.kt
+++ b/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/mydealz/MyDealzDomains.kt
@@ -1,6 +1,6 @@
 /*
  * Léon - The URL Cleaner
- * Copyright (C) 2026 Sven Jacobs
+ * Copyright (C) 2023 Sven Jacobs
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -19,12 +19,18 @@ package com.svenjacobs.app.leon.core.domain.sanitizer.mydealz
 
 internal class MyDealzDomains {
     companion object {
-        internal val DOMAINS_REGEX =
-            Regex(
-                "www\\.mydealz\\.de|mydealz\\.de|" +
-                    "chollometro\\.com|dealabs\\.com|desidime\\.com|hotukdeals\\.com|nl\\.pepper\\.com|" +
-                    "pepper\\.it|pepper\\.pl|pepper\\.ru|promodescuentos\\.com|pelando\\.com\\.br|" +
-                    "preisjaeger\\.at"
-            )
+
+        /**
+         * Regular expression of all domains of the MyDealz network, including their subdomains.
+         *
+         * Meant to be passed to `matchesDomainRegex`, which anchors the expression at the start of
+         * the URL and requires it to cover the complete host.
+         */
+        internal const val DOMAINS_REGEX =
+            "(?:[^./?#:]+\\.)*(?:" +
+                "mydealz\\.de|chollometro\\.com|dealabs\\.com|desidime\\.com|hotukdeals\\.com|" +
+                "nl\\.pepper\\.com|pepper\\.it|pepper\\.pl|pepper\\.ru|promodescuentos\\.com|" +
+                "pelando\\.com\\.br|preisjaeger\\.at" +
+                ")"
     }
 }

--- a/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/mydealz/MyDealzParametersSanitizer.kt
+++ b/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/mydealz/MyDealzParametersSanitizer.kt
@@ -18,6 +18,7 @@
 package com.svenjacobs.app.leon.core.domain.sanitizer.mydealz
 
 import android.content.Context
+import com.svenjacobs.app.leon.core.common.domain.matchesDomainRegex
 import com.svenjacobs.app.leon.core.common.regex.RegexFactory
 import com.svenjacobs.app.leon.core.domain.R
 import com.svenjacobs.app.leon.core.domain.sanitizer.RegexSanitizer
@@ -31,5 +32,6 @@ class MyDealzParametersSanitizer : RegexSanitizer(RegexFactory.AllParameters) {
     override fun getMetadata(context: Context) =
         Sanitizer.Metadata(name = context.getString(R.string.sanitizer_mydealz_parameters_name))
 
-    override fun matchesDomain(input: String) = MyDealzDomains.DOMAINS_REGEX.containsMatchIn(input)
+    override fun matchesDomain(input: String) =
+        input.matchesDomainRegex(MyDealzDomains.DOMAINS_REGEX)
 }

--- a/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/mydealz/MyDealzRedirectsSanitizer.kt
+++ b/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/mydealz/MyDealzRedirectsSanitizer.kt
@@ -18,6 +18,7 @@
 package com.svenjacobs.app.leon.core.domain.sanitizer.mydealz
 
 import android.content.Context
+import com.svenjacobs.app.leon.core.common.domain.matchesDomainRegex
 import com.svenjacobs.app.leon.core.domain.R
 import com.svenjacobs.app.leon.core.domain.sanitizer.Sanitizer
 import com.svenjacobs.app.leon.core.domain.sanitizer.SanitizerId
@@ -29,7 +30,8 @@ class MyDealzRedirectsSanitizer : Sanitizer {
     override fun getMetadata(context: Context) =
         Sanitizer.Metadata(name = context.getString(R.string.sanitizer_mydealz_redirects_name))
 
-    override fun matchesDomain(input: String) = MyDealzDomains.DOMAINS_REGEX.containsMatchIn(input)
+    override fun matchesDomain(input: String) =
+        input.matchesDomainRegex(MyDealzDomains.DOMAINS_REGEX)
 
     override fun invoke(input: String): String {
         val groupValues =

--- a/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/netflix/NetflixSanitizer.kt
+++ b/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/netflix/NetflixSanitizer.kt
@@ -33,5 +33,5 @@ class NetflixSanitizer : RegexSanitizer(regex = RegexFactory.AllParameters) {
         Sanitizer.Metadata(name = context.getString(R.string.sanitizer_netflix_name))
 
     override fun matchesDomain(input: String) =
-        input.matchesDomainRegex(domain = "(help\\.)?netflix.com")
+        input.matchesDomainRegex(domain = "(help\\.)?netflix\\.com")
 }

--- a/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/newegg/NewEggSanitizer.kt
+++ b/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/newegg/NewEggSanitizer.kt
@@ -38,6 +38,7 @@ class NewEggSanitizer : Sanitizer {
     override fun matchesDomain(input: String) = DOMAIN_REGEX.containsMatchIn(input)
 
     private companion object {
-        private val DOMAIN_REGEX = Regex("^(?:https?://)?(?:www\\.)?newegg\\..+(/.+)/p/[0-9A-Z]+")
+        private val DOMAIN_REGEX =
+            Regex("^(?:https?://)?(?:www\\.)?newegg\\.[^/?#:]+(/.+)/p/[0-9A-Z]+")
     }
 }

--- a/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/wikipedia/WikipediaSanitizer.kt
+++ b/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/wikipedia/WikipediaSanitizer.kt
@@ -18,7 +18,7 @@
 package com.svenjacobs.app.leon.core.domain.sanitizer.wikipedia
 
 import android.content.Context
-import com.svenjacobs.app.leon.core.common.domain.matchesDomainRegex
+import com.svenjacobs.app.leon.core.common.domain.matchesSubdomains
 import com.svenjacobs.app.leon.core.common.regex.RegexFactory
 import com.svenjacobs.app.leon.core.domain.R
 import com.svenjacobs.app.leon.core.domain.sanitizer.RegexSanitizer
@@ -32,6 +32,5 @@ class WikipediaSanitizer : RegexSanitizer(regex = RegexFactory.ofParameter("wpro
     override fun getMetadata(context: Context) =
         Sanitizer.Metadata(name = context.getString(R.string.sanitizer_wikipedia_name))
 
-    override fun matchesDomain(input: String) =
-        input.matchesDomainRegex(domain = "(.*\\.)?wikipedia.org")
+    override fun matchesDomain(input: String) = input.matchesSubdomains("wikipedia.org")
 }

--- a/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/youtube/YoutubeMusicSanitizer.kt
+++ b/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/youtube/YoutubeMusicSanitizer.kt
@@ -37,6 +37,6 @@ class YoutubeMusicSanitizer : Sanitizer {
     }
 
     private companion object {
-        private val DOMAIN_REGEX = Regex("(?:https?://)?(music\\.)youtube\\.com")
+        private val DOMAIN_REGEX = Regex("^(?:https?://)?(music\\.)youtube\\.com(?=[:/?#]|\$)")
     }
 }

--- a/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/youtube/YoutubeShortUrlSanitizer.kt
+++ b/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/youtube/YoutubeShortUrlSanitizer.kt
@@ -39,7 +39,7 @@ class YoutubeShortUrlSanitizer : Sanitizer {
     }
 
     private companion object {
-        private val DOMAIN_REGEX = Regex("youtu\\.be")
+        private val DOMAIN_REGEX = Regex("^(?:https?://)?(?:www\\.)?youtu\\.be(?=[:/?#]|\$)")
         private val VIDEO_ID_REGEX = Regex("(?:https?://)?youtu\\.be/(.+)\$")
     }
 }

--- a/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/aliexpress/AliexpressSanitizerTest.kt
+++ b/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/aliexpress/AliexpressSanitizerTest.kt
@@ -50,5 +50,14 @@ class AliexpressSanitizerTest :
                     sanitizer.matchesDomain("de.aliexpress.com/item/12345") shouldBe true
                     sanitizer.matchesDomain("es.aliexpress.com/item/12345") shouldBe true
                 }
+
+                "not match aliexpress.com inside another URL" {
+                    sanitizer.matchesDomain("https://evil.com/?u=de.aliexpress.com/item/1") shouldBe
+                        false
+                }
+
+                "not match host which only starts with aliexpress.com" {
+                    sanitizer.matchesDomain("https://aliexpress.com.evil.com/item/1") shouldBe false
+                }
             }
     })

--- a/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/amazon/AmazonProductSanitizerTest.kt
+++ b/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/amazon/AmazonProductSanitizerTest.kt
@@ -91,5 +91,11 @@ class AmazonProductSanitizerTest :
                             "0DER&psc=1"
                     ) shouldBe true
                 }
+
+                "not match Amazon product link inside another URL" {
+                    sanitizer.matchesDomain(
+                        "https://evil.com/?u=https://amazon.com/dp/B091G3FLL7"
+                    ) shouldBe false
+                }
             }
     })

--- a/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/amazon/AmazonSanitizerTest.kt
+++ b/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/amazon/AmazonSanitizerTest.kt
@@ -34,4 +34,18 @@ class AmazonSanitizerTest :
                     result shouldBe "https://www.amazon.de/gp/css/homepage.html"
                 }
             }
+
+        "matchesDomain" should
+            {
+                "match Amazon domains" {
+                    val sanitizer = AmazonSanitizer()
+                    sanitizer.matchesDomain("https://www.amazon.de/dp/B091G3FLL7/") shouldBe true
+                }
+
+                "not match host which continues after the domain" {
+                    val sanitizer = AmazonSanitizer()
+                    sanitizer.matchesDomain("https://amazon.evil.com?u=/dp/B091G3FLL7/") shouldBe
+                        false
+                }
+            }
     })

--- a/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/ebay/EbaySanitizerTest.kt
+++ b/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/ebay/EbaySanitizerTest.kt
@@ -36,4 +36,18 @@ class EbaySanitizerTest :
                     result shouldBe "https://www.ebay.de/itm/271784973135"
                 }
             }
+
+        "matchesDomain" should
+            {
+                "match eBay article URL" {
+                    val sanitizer = EbaySanitizer()
+                    sanitizer.matchesDomain("https://www.ebay.de/itm/271784973135") shouldBe true
+                }
+
+                "not match host which continues after the domain" {
+                    val sanitizer = EbaySanitizer()
+                    sanitizer.matchesDomain("https://ebay.evil.com?u=/itm/271784973135") shouldBe
+                        false
+                }
+            }
     })

--- a/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/facebook/FacebookSanitizerTest.kt
+++ b/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/facebook/FacebookSanitizerTest.kt
@@ -52,5 +52,13 @@ class FacebookSanitizerTest :
                 "match m.facebook.com" {
                     sanitizer.matchesDomain("https://m.facebook.com") shouldBe true
                 }
+
+                "not match host which only starts with facebook.com" {
+                    sanitizer.matchesDomain("https://facebook.com.evil.com") shouldBe false
+                }
+
+                "not match host where the dot is another character" {
+                    sanitizer.matchesDomain("https://facebook-com") shouldBe false
+                }
             }
     })

--- a/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/flipkart/FlipkartSanitizerTest.kt
+++ b/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/flipkart/FlipkartSanitizerTest.kt
@@ -51,5 +51,17 @@ class FlipkartSanitizerTest :
                 "match *.flipkart.com" {
                     sanitizer.matchesDomain("https://aa.flipkart.com") shouldBe true
                 }
+
+                "match flipkart.com without subdomain" {
+                    sanitizer.matchesDomain("https://flipkart.com") shouldBe true
+                }
+
+                "not match flipkart.com inside another URL" {
+                    sanitizer.matchesDomain("https://evil.com/?u=aa.flipkart.com") shouldBe false
+                }
+
+                "not match host which only starts with flipkart.com" {
+                    sanitizer.matchesDomain("https://aa.flipkart.com.evil.com") shouldBe false
+                }
             }
     })

--- a/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/georiot/GeoRiotSanitizerTest.kt
+++ b/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/georiot/GeoRiotSanitizerTest.kt
@@ -39,4 +39,17 @@ class GeoRiotSanitizerTest :
                             "=ogi&th=1&psc=1&ascsubtag=cbq-us-custom-tracking-20"
                 }
             }
+
+        "matchesDomain" should
+            {
+                "match GeoRiot proxy URL" {
+                    sanitizer.matchesDomain(
+                        "https://target.georiot.com/Proxy.ashx?tsid=8429"
+                    ) shouldBe true
+                }
+
+                "not match host where the dots are other characters" {
+                    sanitizer.matchesDomain("https://target-georiot.com/Proxy-ashx") shouldBe false
+                }
+            }
     })

--- a/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/google/GoogleSearchSanitizerTest.kt
+++ b/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/google/GoogleSearchSanitizerTest.kt
@@ -48,4 +48,15 @@ class GoogleSearchSanitizerTest :
                     result shouldBe "https://www.regextester.com/"
                 }
             }
+
+        "matchesDomain" should
+            {
+                "match Google redirect URL" {
+                    sanitizer.matchesDomain("https://www.google.com/url?q=a") shouldBe true
+                }
+
+                "not match host which continues after the domain" {
+                    sanitizer.matchesDomain("https://google.evil.com?u=/url") shouldBe false
+                }
+            }
     })

--- a/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/linksynergy/LinkSynergySanitizerTest.kt
+++ b/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/linksynergy/LinkSynergySanitizerTest.kt
@@ -37,4 +37,15 @@ class LinkSynergySanitizerTest :
                     result shouldBe "https://www.newegg.com/p/23B-001E-003S3?item=9SIAGREJ3S5851"
                 }
             }
+
+        "matchesDomain" should
+            {
+                "match LinkSynergy link" {
+                    sanitizer.matchesDomain("https://click.linksynergy.com/link?id=a") shouldBe true
+                }
+
+                "not match host which continues after the domain" {
+                    sanitizer.matchesDomain("https://linksynergy.evil.com?u=/link") shouldBe false
+                }
+            }
     })

--- a/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/mydealz/MyDealzParametersSanizierTest.kt
+++ b/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/mydealz/MyDealzParametersSanizierTest.kt
@@ -36,4 +36,18 @@ class MyDealzParametersSanizierTest :
                             "trikot-2383743"
                 }
             }
+
+        "matchesDomain" should
+            {
+                "match MyDealz domains" {
+                    val sanitizer = MyDealzParametersSanitizer()
+                    sanitizer.matchesDomain("https://www.mydealz.de/deals/a-1") shouldBe true
+                    sanitizer.matchesDomain("https://www.hotukdeals.com/deals/a-1") shouldBe true
+                }
+
+                "not match MyDealz domain inside another URL" {
+                    val sanitizer = MyDealzParametersSanitizer()
+                    sanitizer.matchesDomain("https://evil.com/?u=mydealz.de") shouldBe false
+                }
+            }
     })

--- a/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/mydealz/MyDealzRedirectsSanizierTest.kt
+++ b/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/mydealz/MyDealzRedirectsSanizierTest.kt
@@ -42,4 +42,18 @@ class MyDealzRedirectsSanizierTest :
                     result shouldBe "https://preisjaeger.at/deals/a-2117879"
                 }
             }
+
+        "matchesDomain" should
+            {
+                "match MyDealz domains" {
+                    val sanitizer = MyDealzRedirectsSanitizer()
+                    sanitizer.matchesDomain("https://www.mydealz.de/deals/a-1") shouldBe true
+                    sanitizer.matchesDomain("https://www.hotukdeals.com/deals/a-1") shouldBe true
+                }
+
+                "not match MyDealz domain inside another URL" {
+                    val sanitizer = MyDealzRedirectsSanitizer()
+                    sanitizer.matchesDomain("https://evil.com/?u=mydealz.de") shouldBe false
+                }
+            }
     })

--- a/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/netflix/NetflixSanitizerTest.kt
+++ b/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/netflix/NetflixSanitizerTest.kt
@@ -64,5 +64,13 @@ class NetflixSanitizerTest :
                 "match help.netflix.com" {
                     sanitizer.matchesDomain("https://help.netflix.com") shouldBe true
                 }
+
+                "not match host which only starts with netflix.com" {
+                    sanitizer.matchesDomain("https://netflix.com.evil.com") shouldBe false
+                }
+
+                "not match host where the dot is another character" {
+                    sanitizer.matchesDomain("https://netflix-com") shouldBe false
+                }
             }
     })

--- a/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/newegg/NewEggSanitizerTest.kt
+++ b/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/newegg/NewEggSanitizerTest.kt
@@ -35,4 +35,21 @@ class NewEggSanitizerTest :
                     result shouldBe "https://www.newegg.com/p/N82E16834360174"
                 }
             }
+
+        "matchesDomain" should
+            {
+                "match NewEgg product URL" {
+                    val sanitizer = NewEggSanitizer()
+                    sanitizer.matchesDomain(
+                        "https://www.newegg.com/some-product/p/N82E16834360174"
+                    ) shouldBe true
+                }
+
+                "not match host which continues after the domain" {
+                    val sanitizer = NewEggSanitizer()
+                    sanitizer.matchesDomain(
+                        "https://newegg.evil.com?u=/a/p/N82E16834360174"
+                    ) shouldBe false
+                }
+            }
     })

--- a/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/wikipedia/WikipediaSanitizerTest.kt
+++ b/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/wikipedia/WikipediaSanitizerTest.kt
@@ -49,5 +49,17 @@ class WikipediaSanitizerTest :
                 "don't match google.com" {
                     sanitizer.matchesDomain("https://google.com") shouldBe false
                 }
+
+                "don't match wikipedia.org inside another URL" {
+                    sanitizer.matchesDomain("https://evil.com/?u=en.wikipedia.org") shouldBe false
+                }
+
+                "don't match host which only starts with wikipedia.org" {
+                    sanitizer.matchesDomain("https://wikipedia.org.evil.com") shouldBe false
+                }
+
+                "don't match host where the dot is another character" {
+                    sanitizer.matchesDomain("https://wikipedia-org") shouldBe false
+                }
             }
     })

--- a/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/youtube/YoutubeMusicSanitizerTest.kt
+++ b/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/youtube/YoutubeMusicSanitizerTest.kt
@@ -46,4 +46,16 @@ class YoutubeMusicSanitizerTest :
                             "UrAH_0ZI"
                 }
             }
+
+        "matchesDomain" should
+            {
+                "match music.youtube.com" {
+                    sanitizer.matchesDomain("https://music.youtube.com/playlist?list=a") shouldBe
+                        true
+                }
+
+                "not match music.youtube.com inside another URL" {
+                    sanitizer.matchesDomain("https://evil.com/?u=music.youtube.com") shouldBe false
+                }
+            }
     })

--- a/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/youtube/YoutubeShortUrlSanitizerTest.kt
+++ b/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/youtube/YoutubeShortUrlSanitizerTest.kt
@@ -30,4 +30,17 @@ class YoutubeShortUrlSanitizerTest :
                     result shouldBe "https://www.youtube.com/watch?v=5HaUOgW5BlA"
                 }
             }
+
+        "matchesDomain" should
+            {
+                "match youtu.be" {
+                    val sanitizer = YoutubeShortUrlSanitizer()
+                    sanitizer.matchesDomain("https://youtu.be/5HaUOgW5BlA") shouldBe true
+                }
+
+                "not match youtu.be inside another URL" {
+                    val sanitizer = YoutubeShortUrlSanitizer()
+                    sanitizer.matchesDomain("https://evil.com/youtu.be/5HaUOgW5BlA") shouldBe false
+                }
+            }
     })


### PR DESCRIPTION
## TL;DR

`matchesDomainRegex` ended in `.*`, so the domain pattern only had to be a *prefix* of the host and every domain-specific sanitizer also matched lookalike hosts such as `example.com.evil.com`. The shared helper now requires the pattern to cover the host completely, and the individual sanitizer patterns — which the helper cannot fix on their own — are tightened alongside it.

Closes #795

## The shared helper

`matchesDomainRegex` no longer matches the whole string. It matches the pattern from the start and then checks that the match reaches the end of the host, which is the first `:`, `/`, `?` or `#` after the scheme:

```kotlin
val match = Regex("^(?:https?://)?(?:www\\.)?(?:$domain)").find(this) ?: return false
return match.range.last + 1 >= hostEndIndex()
```

- **Ports still match.** The host ends at `:`, so `https://example.com:8443/p` is matched by `example.com`, as before.
- **Patterns which reach into the path still work.** `google\.com/maps` produces a match *longer* than the host, which passes the check. Only patterns that stop short of the host end are rejected.

`matchesSubdomains` had the same hole plus a leading `.*`, which matched the domain anywhere at all — `https://evil.com/?u=feishu.cn` and `notfeishu.cn` both passed. It is now expressed in terms of the fixed helper as an optional chain of leading labels.

## The sanitizer patterns

Three defects, none of which the helper can catch:

| Problem | Sanitizers | Example that wrongly matched |
| --- | --- | --- |
| Unescaped `.`, matching any character | Netflix, Facebook, Wikipedia, GeoRiot | `https://target-georiot.com/Proxy-ashx` |
| Wildcard crosses the host boundary | AliExpress, Amazon, eBay, Google Search, LinkSynergy, Newegg, Flipkart, Wikipedia | `https://ebay.evil.com?u=/itm/1` |
| `containsMatchIn` on an unanchored pattern | YouTube Music, YouTube short URLs, Amazon products, MyDealz | `https://evil.com/?u=music.youtube.com` |

The third group is the most severe, because two of those sanitizers rewrite the URL rather than only stripping parameters. `AmazonProductSanitizer` turned `https://evil.com/?u=https://amazon.com/dp/B01` into `https://amazon.com/dp/B01/`, and `YoutubeMusicSanitizer` deleted `music.` out of the middle of a query string.

Two related changes came out of this:

- `MyDealzDomains.DOMAINS_REGEX` is now a pattern string for `matchesDomainRegex` instead of a `Regex` used with `containsMatchIn`, so both MyDealz sanitizers are anchored. Subdomains stay allowed.
- `LinkSynergySanitizer` never matched its own links: real ones are hosted at `click.linksynergy.com`, which the pattern rejected because it allowed no subdomain. It now matches, so the sanitizer actually runs.

### What is deliberately not fixed

Where a sanitizer covers a brand across all of its ccTLDs — `amazon\.[^/?#:]+`, `ebay\.…`, `google\.…` — `amazon.evil.com` is structurally indistinguishable from `amazon.com.br` without a public suffix list. Those wildcards are now confined to the host, but they still accept a lookalike. Since these sanitizers only strip parameters, a false positive is harmless while a false negative leaks tracking data, so the loose end is left loose on purpose. AliExpress is the exception: it has no multi-label TLD, so its pattern now rejects a dot in that position.

## Testing

No behaviour change is intended for any legitimate URL. Every pre-existing test passes untouched.

1. `./gradlew :core-common:test` — 14 tests, 5 new: lookalike hosts, the `@` user-information trick, ports, and `matchesSubdomains`.
2. `./gradlew :core-domain:test` — 250 tests, 33 new, one pair per tightened sanitizer: a real URL that must still match and the lookalike that must not.
3. By hand: share `https://substack.com.evil.com/p/article?r=1` with Léon — it must be left untouched, while `https://substack.com/p/article?r=1` is still cleaned.

_Written by Claude Code (Claude Opus 5)_
