### PR TITLE
ci: check out main before incrementing the version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -112,6 +112,8 @@ jobs:
     needs: deploy
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: main
 
       - name: Increment version code
         run: sed -i 's/versionCode = [0-9]*/versionCode = '$(awk '/versionCode =/{print $3=$3+1}' app/build.gradle.kts)'/g' app/build.gradle.kts


### PR DESCRIPTION
## TL;DR

The deploy workflow runs on a tag push, so `actions/checkout` in the `increment-version` job landed on the tag's commit in a detached HEAD state, which `git-auto-commit` warned about and then had to recover from. Checking out `main` explicitly removes the warning — that is where the version bump is committed anyway.

Warning seen in [run 33414595846](https://github.com/leon-cleaning-services/leon/actions/runs/33414595846).

🤖 Generated with [Claude Code](https://claude.com/claude-code)