### PR TITLE
chore: raise minSdk to 24 (Android 7.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 parameters from a URL before sharing. Its usage is simple, integrating into Android's standard
 sharing mechanism.
 
-Léon runs on Android 6.0 and later, is open source and does not contain any tracking or advertising
+Léon runs on Android 7.0 and later, is open source and does not contain any tracking or advertising
 frameworks. Léon does not collect any data about you.
 
 The benefits of removing tracking parameters are:

--- a/buildSrc/src/main/kotlin/Android.kt
+++ b/buildSrc/src/main/kotlin/Android.kt
@@ -17,7 +17,7 @@
  */
 
 object Android {
-    const val minSdk = 23
+    const val minSdk = 24
     const val targetSdk = 37
     const val compileSdk = 37
 }


### PR DESCRIPTION
In order to be able to keep updating Léon's [dependencies](https://issuetracker.google.com/issues/474169350), we (unfortunately) have to raise the minSdk of this application to `24` (Android 7.0).