### PR TITLE
feat(sanitizer): add Humble Bundle sanitizer

### DIFF
--- a/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/catalog/Catalog.kt
+++ b/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/catalog/Catalog.kt
@@ -61,6 +61,7 @@ val AllSanitizers: SanitizersCollection =
         GoogleSearch,
         GoogleStore,
         Heise,
+        HumbleBundle,
         Ikea,
         IlMessaggero,
         Instagram,

--- a/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/catalog/HumbleBundle.kt
+++ b/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/catalog/HumbleBundle.kt
@@ -1,0 +1,33 @@
+/*
+ * Léon - The URL Cleaner
+ * Copyright (C) 2026 Sven Jacobs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.svenjacobs.app.leon.core.domain.sanitizer.catalog
+
+import com.svenjacobs.app.leon.core.domain.sanitizer.HostMatch
+import com.svenjacobs.app.leon.core.domain.sanitizer.Match
+import com.svenjacobs.app.leon.core.domain.sanitizer.Rule
+import com.svenjacobs.app.leon.core.domain.sanitizer.Sanitizer
+import com.svenjacobs.app.leon.core.domain.sanitizer.SanitizerId
+import kotlinx.collections.immutable.persistentListOf
+
+val HumbleBundle =
+    Sanitizer(
+        id = SanitizerId("humblebundle"),
+        name = "Humble Bundle",
+        rules = persistentListOf(Rule.RemoveParameters(".*")),
+        match = persistentListOf(Match(HostMatch.Domain("humblebundle.com"))),
+    )

--- a/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/humblebundle/HumbleBundleTest.kt
+++ b/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/humblebundle/HumbleBundleTest.kt
@@ -1,0 +1,54 @@
+/*
+ * Léon - The URL Cleaner
+ * Copyright (C) 2026 Sven Jacobs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.svenjacobs.app.leon.core.domain.sanitizer.humblebundle
+
+import com.svenjacobs.app.leon.core.domain.sanitizer.SanitizerSpec
+import com.svenjacobs.app.leon.core.domain.sanitizer.catalog.HumbleBundle
+import io.kotest.matchers.shouldBe
+
+class HumbleBundleTest :
+    SanitizerSpec(
+        HumbleBundle,
+        {
+            "clean" should
+                {
+                    "remove all parameters" {
+                        clean(
+                            "https://www.humblebundle.com/books/no-kings-library-berrettkoehler-books?mcI" +
+                                "D=102:69f1456f540ada90b00cd16c:ot:668703f5cbbc2d1867d8cdcc:1&linkID=69f14" +
+                                "7a276fa2560470c48b4&utm_source=Humble+Bundle+Newsletter&utm_content=cta_b" +
+                                "utton&utm_medium=email&utm_campaign=nokingslibraryberrettkoehler_bookbundle"
+                        ) shouldBe
+                            "https://www.humblebundle.com/books/no-kings-library-berrettkoehler-books"
+                    }
+                }
+
+            "matches" should
+                {
+                    "match humblebundle.com" { matches("https://humblebundle.com") shouldBe true }
+
+                    "match www.humblebundle.com" {
+                        matches("https://www.humblebundle.com") shouldBe true
+                    }
+
+                    "not match a lookalike host" {
+                        matches("https://humblebundle.com.evil.com") shouldBe false
+                    }
+                }
+        },
+    )


### PR DESCRIPTION
## TL;DR

Adds a sanitizer that removes all tracking parameters (`mcID`, `linkID`, `utm_*`) from `humblebundle.com` links.

## Testing

1. Share `https://www.humblebundle.com/books/no-kings-library-berrettkoehler-books?mcID=102:69f1456f540ada90b00cd16c:ot:668703f5cbbc2d1867d8cdcc:1&linkID=69f147a276fa2560470c48b4&utm_source=Humble+Bundle+Newsletter&utm_content=cta_button&utm_medium=email&utm_campaign=nokingslibraryberrettkoehler_bookbundle` with Léon.
2. The cleaned URL must have no query parameters.
3. Run `./gradlew :core-domain:test --tests "*HumbleBundle*"`.

Closes #758