### PR TITLE
feat(sanitizer): add Il Sole 24 Ore sanitizer

### DIFF
--- a/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/catalog/Catalog.kt
+++ b/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/catalog/Catalog.kt
@@ -63,6 +63,7 @@ val AllSanitizers: SanitizersCollection =
         Heise,
         Ikea,
         IlMessaggero,
+        IlSole24Ore,
         Instagram,
         Jd,
         Jdoqocy,

--- a/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/catalog/IlSole24Ore.kt
+++ b/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/catalog/IlSole24Ore.kt
@@ -1,0 +1,33 @@
+/*
+ * Léon - The URL Cleaner
+ * Copyright (C) 2026 Sven Jacobs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.svenjacobs.app.leon.core.domain.sanitizer.catalog
+
+import com.svenjacobs.app.leon.core.domain.sanitizer.HostMatch
+import com.svenjacobs.app.leon.core.domain.sanitizer.Match
+import com.svenjacobs.app.leon.core.domain.sanitizer.Rule
+import com.svenjacobs.app.leon.core.domain.sanitizer.Sanitizer
+import com.svenjacobs.app.leon.core.domain.sanitizer.SanitizerId
+import kotlinx.collections.immutable.persistentListOf
+
+val IlSole24Ore =
+    Sanitizer(
+        id = SanitizerId("ilsole24ore"),
+        name = "Il Sole 24 Ore",
+        rules = persistentListOf(Rule.RemoveParameters(".*")),
+        match = persistentListOf(Match(HostMatch.Domain("ilsole24ore.com"))),
+    )

--- a/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/ilsole24ore/IlSole24OreTest.kt
+++ b/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/ilsole24ore/IlSole24OreTest.kt
@@ -1,0 +1,53 @@
+/*
+ * Léon - The URL Cleaner
+ * Copyright (C) 2026 Sven Jacobs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.svenjacobs.app.leon.core.domain.sanitizer.ilsole24ore
+
+import com.svenjacobs.app.leon.core.domain.sanitizer.SanitizerSpec
+import com.svenjacobs.app.leon.core.domain.sanitizer.catalog.IlSole24Ore
+import io.kotest.matchers.shouldBe
+
+class IlSole24OreTest :
+    SanitizerSpec(
+        IlSole24Ore,
+        {
+            "clean" should
+                {
+                    "remove all parameters" {
+                        clean(
+                            "https://www.ilsole24ore.com/art/la-rivoluzione-farmaci-dimagranti-che-potreb" +
+                                "bero-prevenire-anche-cancro-AImYSJBC?cmpid=waw"
+                        ) shouldBe
+                            "https://www.ilsole24ore.com/art/la-rivoluzione-farmaci-dimagranti-che-potreb" +
+                                "bero-prevenire-anche-cancro-AImYSJBC"
+                    }
+                }
+
+            "matches" should
+                {
+                    "match ilsole24ore.com" { matches("https://ilsole24ore.com") shouldBe true }
+
+                    "match www.ilsole24ore.com" {
+                        matches("https://www.ilsole24ore.com") shouldBe true
+                    }
+
+                    "not match a lookalike host" {
+                        matches("https://ilsole24ore.com.evil.com") shouldBe false
+                    }
+                }
+        },
+    )


### PR DESCRIPTION
## TL;DR

Adds a sanitizer that removes all tracking parameters (such as `cmpid`) from `ilsole24ore.com` article links.

## Testing

1. Share `https://www.ilsole24ore.com/art/la-rivoluzione-farmaci-dimagranti-che-potrebbero-prevenire-anche-cancro-AImYSJBC?cmpid=waw` with Léon.
2. The cleaned URL must have no query parameters.
3. Run `./gradlew :core-domain:test --tests "*IlSole24Ore*"`.

Closes #729