### PR TITLE
feat(sanitizer): add AvantLink sanitizer

### DIFF
--- a/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/catalog/AvantLink.kt
+++ b/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/catalog/AvantLink.kt
@@ -1,0 +1,41 @@
+/*
+ * Léon - The URL Cleaner
+ * Copyright (C) 2026 Sven Jacobs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.svenjacobs.app.leon.core.domain.sanitizer.catalog
+
+import com.svenjacobs.app.leon.core.domain.sanitizer.Decode
+import com.svenjacobs.app.leon.core.domain.sanitizer.HostMatch
+import com.svenjacobs.app.leon.core.domain.sanitizer.Match
+import com.svenjacobs.app.leon.core.domain.sanitizer.Rule
+import com.svenjacobs.app.leon.core.domain.sanitizer.Sanitizer
+import com.svenjacobs.app.leon.core.domain.sanitizer.SanitizerId
+import com.svenjacobs.app.leon.core.domain.sanitizer.Source
+import kotlinx.collections.immutable.persistentListOf
+
+val AvantLink =
+    Sanitizer(
+        id = SanitizerId("avantlink"),
+        name = "AvantLink",
+        // The affiliate target is hidden, percent-encoded, in the "url" parameter of the referral
+        // link: /click.php?...&url=<target>
+        rules =
+            persistentListOf(
+                Rule.Follow(Source.Parameter("url"), persistentListOf(Decode.PercentDecode))
+            ),
+        match =
+            persistentListOf(Match(HostMatch.Domain("avantlink.com"), pathPrefix = "/click.php")),
+    )

--- a/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/catalog/Catalog.kt
+++ b/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/catalog/Catalog.kt
@@ -36,6 +36,7 @@ val AllSanitizers: SanitizersCollection =
         AolSearch,
         AtAnalytics,
         AutoTrader,
+        AvantLink,
         Bilibili,
         BlueskyRedirect,
         CarGurus,

--- a/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/avantlink/AvantLinkTest.kt
+++ b/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/avantlink/AvantLinkTest.kt
@@ -1,0 +1,58 @@
+/*
+ * Léon - The URL Cleaner
+ * Copyright (C) 2026 Sven Jacobs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.svenjacobs.app.leon.core.domain.sanitizer.avantlink
+
+import com.svenjacobs.app.leon.core.domain.sanitizer.SanitizerSpec
+import com.svenjacobs.app.leon.core.domain.sanitizer.catalog.AvantLink
+import io.kotest.matchers.shouldBe
+
+class AvantLinkTest :
+    SanitizerSpec(
+        AvantLink,
+        {
+            "clean" should
+                {
+                    "extract target from click.php referral link" {
+                        clean(
+                            "https://www.avantlink.com/click.php?tt=cl&merchant_id=68286571-393d-411e-9" +
+                                "a0f-d1c2fa0648d6&website_id=37e930a6-52be-4816-9903-81d2e873459d&url=http" +
+                                "s%3A%2F%2Fgreymantactical.com%2Fcollections%2Fshoprmpseries"
+                        ) shouldBe "https://greymantactical.com/collections/shoprmpseries"
+                    }
+                }
+
+            "matches" should
+                {
+                    "match avantlink.com click.php link" {
+                        matches(
+                            "https://www.avantlink.com/click.php?url=https%3A%2F%2Fexample.com"
+                        ) shouldBe true
+                    }
+
+                    "not match a lookalike host" {
+                        matches(
+                            "https://avantlink.com.evil.com/click.php?url=https%3A%2F%2Fexample.com"
+                        ) shouldBe false
+                    }
+
+                    "not match other avantlink.com paths" {
+                        matches("https://www.avantlink.com/") shouldBe false
+                    }
+                }
+        },
+    )


### PR DESCRIPTION
## TL;DR

AvantLink referral links hide the affiliate target, percent-encoded, in the `url` parameter of `/click.php`. This adds a sanitizer that extracts it.

## Testing

1. Share `https://www.avantlink.com/click.php?tt=cl&merchant_id=68286571-393d-411e-9a0f-d1c2fa0648d6&website_id=37e930a6-52be-4816-9903-81d2e873459d&url=https%3A%2F%2Fgreymantactical.com%2Fcollections%2Fshoprmpseries` with Léon.
2. The cleaned URL should be `https://greymantactical.com/collections/shoprmpseries`.
3. Run `./gradlew :core-domain:test --tests "*AvantLink*"`.

Closes #608