### PR TITLE
feat(history): add a history of cleaned URLs

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,6 +26,8 @@ plugins {
     kotlin("plugin.parcelize")
     id("org.jetbrains.kotlin.plugin.compose")
     alias(libs.plugins.aboutlibraries)
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.room3)
 }
 
 java {
@@ -117,6 +119,8 @@ kotlin {
     }
 }
 
+room3 { schemaDirectory("$projectDir/schemas") }
+
 dependencies {
     val composeBom = platform(libs.androidx.compose.bom)
     implementation(composeBom)
@@ -148,10 +152,15 @@ dependencies {
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.androidx.browser)
     implementation(libs.jakewharton.timber)
+    implementation(libs.androidx.room3.runtime)
+    ksp(libs.androidx.room3.compiler)
 
     debugImplementation(libs.facebook.stetho)
 
     androidTestImplementation(composeBom)
+    androidTestImplementation(libs.androidx.test.ext.junit)
+    androidTestImplementation(libs.androidx.test.runner)
+    androidTestImplementation(libs.kotlinx.coroutines.test)
 
     testImplementation(libs.kotest.runner.junit5)
     testImplementation(libs.kotest.assertions.core)

--- a/app/schemas/com.svenjacobs.app.leon.db.AppDatabase/1.json
+++ b/app/schemas/com.svenjacobs.app.leon.db.AppDatabase/1.json
@@ -1,0 +1,43 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 1,
+    "identityHash": "eff00df5236ed41d174b0c42c918ab80",
+    "entities": [
+      {
+        "tableName": "history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `url` TEXT NOT NULL, `at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "at",
+            "columnName": "at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'eff00df5236ed41d174b0c42c918ab80')"
+    ]
+  }
+}

--- a/app/src/androidTest/kotlin/com/svenjacobs/app/leon/db/HistoryDaoTest.kt
+++ b/app/src/androidTest/kotlin/com/svenjacobs/app/leon/db/HistoryDaoTest.kt
@@ -1,0 +1,89 @@
+/*
+ * Léon - The URL Cleaner
+ * Copyright (C) 2026 Sven Jacobs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.svenjacobs.app.leon.db
+
+import android.content.Context
+import androidx.room3.Room
+import androidx.sqlite.driver.AndroidSQLiteDriver
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class HistoryDaoTest {
+
+    private lateinit var db: AppDatabase
+    private lateinit var dao: HistoryDao
+
+    @Before
+    fun setUp() {
+        db =
+            Room.inMemoryDatabaseBuilder<AppDatabase>(
+                    ApplicationProvider.getApplicationContext<Context>()
+                )
+                .setDriver(AndroidSQLiteDriver())
+                .build()
+        dao = db.historyDao()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun recordingTwoIdsPutsTheNewerFirst() = runTest {
+        dao.record(id = "id-1", url = "https://example.com/a", at = 1_000L)
+        dao.record(id = "id-2", url = "https://example.com/b", at = 2_000L)
+
+        val entries = dao.entries().first()
+
+        assertEquals(listOf("id-2", "id-1"), entries.map { it.id })
+    }
+
+    @Test
+    fun recordingTheSameIdTwiceUpdatesTheUrlAndKeepsTheOriginalAt() = runTest {
+        dao.record(id = "id-1", url = "https://example.com/a", at = 1_000L)
+        dao.record(id = "id-1", url = "https://example.com/a-edited", at = 2_000L)
+
+        val entries = dao.entries().first()
+
+        assertEquals(1, entries.size)
+        assertEquals("https://example.com/a-edited", entries.first().url)
+        assertEquals(1_000L, entries.first().at)
+    }
+
+    @Test
+    fun recordingElevenIdsLeavesTenWithTheOldestGone() = runTest {
+        repeat(11) { i ->
+            dao.record(id = "id-$i", url = "https://example.com/$i", at = i.toLong())
+        }
+
+        val entries = dao.entries().first()
+
+        assertEquals(HISTORY_MAX_SIZE, entries.size)
+        assertEquals(false, entries.any { it.id == "id-0" })
+        assertEquals(true, entries.any { it.id == "id-10" })
+    }
+}

--- a/app/src/main/kotlin/com/svenjacobs/app/leon/datastore/AppDataStoreManager.kt
+++ b/app/src/main/kotlin/com/svenjacobs/app/leon/datastore/AppDataStoreManager.kt
@@ -106,6 +106,13 @@ class AppDataStoreManager(private val context: Context = AppContext) {
             if (id != null && at != null) LastInput(id, at) else null
         }
 
+    suspend fun setHistoryEnabled(enabled: Boolean) {
+        context.dataStore.edit { it[KEY_HISTORY_ENABLED] = enabled }
+    }
+
+    val historyEnabled: Flow<Boolean> =
+        context.dataStore.data.map { preferences -> preferences[KEY_HISTORY_ENABLED] ?: true }
+
     private companion object {
         private val KEY_VERSION_CODE = intPreferencesKey("version_code")
         private val KEY_ACTION_AFTER_CLEAN = stringPreferencesKey("action_after_clean")
@@ -116,5 +123,6 @@ class AppDataStoreManager(private val context: Context = AppContext) {
         private val KEY_AUTO_RESET = stringPreferencesKey("auto_reset")
         private val KEY_LAST_INPUT_ID = stringPreferencesKey("last_input_id")
         private val KEY_LAST_INPUT_AT = longPreferencesKey("last_input_at")
+        private val KEY_HISTORY_ENABLED = booleanPreferencesKey("history_enabled")
     }
 }

--- a/app/src/main/kotlin/com/svenjacobs/app/leon/db/AppDatabase.kt
+++ b/app/src/main/kotlin/com/svenjacobs/app/leon/db/AppDatabase.kt
@@ -1,8 +1,6 @@
-@file:Suppress("UnstableApiUsage")
-
 /*
  * Léon - The URL Cleaner
- * Copyright (C) 2022 Sven Jacobs
+ * Copyright (C) 2026 Sven Jacobs
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,28 +15,12 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+package com.svenjacobs.app.leon.db
 
-pluginManagement {
-    repositories {
-        google()
-        gradlePluginPortal()
-        mavenCentral()
-    }
+import androidx.room3.Database
+import androidx.room3.RoomDatabase
+
+@Database(entities = [HistoryEntry::class], version = 1, exportSchema = true)
+abstract class AppDatabase : RoomDatabase() {
+    abstract fun historyDao(): HistoryDao
 }
-
-plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
-}
-
-dependencyResolutionManagement {
-    repositories {
-        google()
-        mavenCentral()
-    }
-}
-
-rootProject.name = "Leon"
-include(
-    ":core-domain",
-    ":app",
-)

--- a/app/src/main/kotlin/com/svenjacobs/app/leon/db/HistoryDao.kt
+++ b/app/src/main/kotlin/com/svenjacobs/app/leon/db/HistoryDao.kt
@@ -1,0 +1,61 @@
+/*
+ * Léon - The URL Cleaner
+ * Copyright (C) 2026 Sven Jacobs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.svenjacobs.app.leon.db
+
+import androidx.room3.Dao
+import androidx.room3.Insert
+import androidx.room3.OnConflictStrategy
+import androidx.room3.Query
+import androidx.room3.Transaction
+import kotlinx.coroutines.flow.Flow
+
+const val HISTORY_MAX_SIZE = 10
+
+@Dao
+interface HistoryDao {
+
+    @Query("SELECT * FROM history ORDER BY at DESC") fun entries(): Flow<List<HistoryEntry>>
+
+    /**
+     * Records [url] for the session [id]: updates the row in place while the user is still working
+     * on the same shared text — ticking a change off must not push a second entry — and inserts a
+     * new one otherwise. An updated row keeps its original [HistoryEntry.at]: that says when the
+     * URL was cleaned, not when it was last edited.
+     */
+    @Transaction
+    suspend fun record(id: String, url: String, at: Long, max: Int = HISTORY_MAX_SIZE) {
+        if (updateUrl(id, url) == 0) {
+            insert(HistoryEntry(id = id, url = url, at = at))
+            trim(max)
+        }
+    }
+
+    @Query("UPDATE history SET url = :url WHERE id = :id")
+    suspend fun updateUrl(id: String, url: String): Int
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE) suspend fun insert(entry: HistoryEntry)
+
+    @Query(
+        "DELETE FROM history WHERE id NOT IN (SELECT id FROM history ORDER BY at DESC LIMIT :max)"
+    )
+    suspend fun trim(max: Int)
+
+    @Query("DELETE FROM history WHERE id = :id") suspend fun delete(id: String)
+
+    @Query("DELETE FROM history") suspend fun clear()
+}

--- a/app/src/main/kotlin/com/svenjacobs/app/leon/db/HistoryEntry.kt
+++ b/app/src/main/kotlin/com/svenjacobs/app/leon/db/HistoryEntry.kt
@@ -1,8 +1,6 @@
-@file:Suppress("UnstableApiUsage")
-
 /*
  * Léon - The URL Cleaner
- * Copyright (C) 2022 Sven Jacobs
+ * Copyright (C) 2026 Sven Jacobs
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,28 +15,16 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+package com.svenjacobs.app.leon.db
 
-pluginManagement {
-    repositories {
-        google()
-        gradlePluginPortal()
-        mavenCentral()
-    }
-}
+import androidx.room3.Entity
+import androidx.room3.PrimaryKey
 
-plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
-}
-
-dependencyResolutionManagement {
-    repositories {
-        google()
-        mavenCentral()
-    }
-}
-
-rootProject.name = "Leon"
-include(
-    ":core-domain",
-    ":app",
+@Entity(tableName = "history")
+data class HistoryEntry(
+    /** The id of the input this URL was cleaned from — see MainActivity's EXTRA_SOURCE_TEXT_ID. */
+    @PrimaryKey val id: String,
+    val url: String,
+    /** When the URL was cleaned, epoch millis. */
+    val at: Long,
 )

--- a/app/src/main/kotlin/com/svenjacobs/app/leon/inject/AppContainer.kt
+++ b/app/src/main/kotlin/com/svenjacobs/app/leon/inject/AppContainer.kt
@@ -18,8 +18,12 @@
 package com.svenjacobs.app.leon.inject
 
 import android.content.Context
+import androidx.room3.Room
+import androidx.sqlite.driver.AndroidSQLiteDriver
 import com.svenjacobs.app.leon.datastore.AppDataStoreManager
 import com.svenjacobs.app.leon.datastore.SanitizerDataStoreManager
+import com.svenjacobs.app.leon.db.AppDatabase
+import com.svenjacobs.app.leon.db.HistoryDao
 
 object AppContainer {
 
@@ -32,4 +36,11 @@ object AppContainer {
 
     val AppDataStoreManager: AppDataStoreManager by lazy { AppDataStoreManager() }
     val SanitizerDataStoreManager: SanitizerDataStoreManager by lazy { SanitizerDataStoreManager() }
+
+    val AppDatabase: AppDatabase by lazy {
+        Room.databaseBuilder<AppDatabase>(AppContext, "leon")
+            .setDriver(AndroidSQLiteDriver())
+            .build()
+    }
+    val HistoryDao: HistoryDao by lazy { AppDatabase.historyDao() }
 }

--- a/app/src/main/kotlin/com/svenjacobs/app/leon/ui/common/UrlActions.kt
+++ b/app/src/main/kotlin/com/svenjacobs/app/leon/ui/common/UrlActions.kt
@@ -1,0 +1,68 @@
+/*
+ * Léon - The URL Cleaner
+ * Copyright (C) 2026 Sven Jacobs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.svenjacobs.app.leon.ui.common
+
+import android.content.ClipData
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.browser.customtabs.CustomTabsIntent
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.ui.platform.Clipboard
+import androidx.compose.ui.platform.toClipEntry
+import androidx.core.net.toUri
+
+fun shareText(context: Context, text: String, chooserTitle: String) {
+    val intent =
+        Intent(Intent.ACTION_SEND).apply {
+            type = "text/plain"
+            addCategory(Intent.CATEGORY_DEFAULT)
+            putExtra(Intent.EXTRA_TEXT, text)
+        }
+
+    context.startActivity(Intent.createChooser(intent, chooserTitle))
+}
+
+/**
+ * Returns without doing anything when Léon is the default browser — opening would just reopen Léon.
+ */
+fun openUrl(context: Context, url: String, customTabs: Boolean, chooserTitle: String) {
+    if (isDefaultBrowser(context)) return
+
+    if (customTabs) {
+        val intent =
+            CustomTabsIntent.Builder().setColorScheme(CustomTabsIntent.COLOR_SCHEME_SYSTEM).build()
+
+        intent.launchUrl(context, url.toUri())
+    } else {
+        val uri = runCatching { Uri.parse(url) }.getOrNull() ?: return
+        val intent = Intent(Intent.ACTION_VIEW, uri)
+
+        context.startActivity(Intent.createChooser(intent, chooserTitle))
+    }
+}
+
+suspend fun copyToClipboard(
+    clipboard: Clipboard,
+    snackbarHostState: SnackbarHostState,
+    text: String,
+    message: String,
+) {
+    clipboard.setClipEntry(ClipData.newPlainText(text, text).toClipEntry())
+    snackbarHostState.showSnackbar(message)
+}

--- a/app/src/main/kotlin/com/svenjacobs/app/leon/ui/screens/history/HistoryScreen.kt
+++ b/app/src/main/kotlin/com/svenjacobs/app/leon/ui/screens/history/HistoryScreen.kt
@@ -41,10 +41,11 @@ import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.SwipeToDismissBox
+import androidx.compose.material3.SwipeToDismissBoxDefaults
+import androidx.compose.material3.SwipeToDismissBoxState
 import androidx.compose.material3.SwipeToDismissBoxValue
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -228,7 +229,20 @@ private fun HistoryRow(
     val clipboardMessage = stringResource(R.string.clipboard_message)
     var menuFor by remember { mutableStateOf<String?>(null) }
 
-    val dismissState = rememberSwipeToDismissBoxState()
+    // Deliberately `remember`, not `rememberSwipeToDismissBoxState`: that one is backed by
+    // `rememberSaveable`, and a LazyColumn stores an item's saveable state under the item's key.
+    // A row swiped away and then brought back by Undo would therefore return with its swipe
+    // restored — dismissed, drawn fully off to the side, an invisible gap in the list. A
+    // half-finished swipe is not worth preserving across anything, so this state is not saved at
+    // all and a re-entering row always starts settled.
+    val positionalThreshold = SwipeToDismissBoxDefaults.positionalThreshold
+    val dismissState =
+        remember(positionalThreshold) {
+            SwipeToDismissBoxState(
+                initialValue = SwipeToDismissBoxValue.Settled,
+                positionalThreshold = positionalThreshold,
+            )
+        }
 
     Box(modifier = modifier) {
         SwipeToDismissBox(
@@ -249,11 +263,9 @@ private fun HistoryRow(
                     SwipeToDismissBoxValue.Settled -> {}
                 }
 
-                // Always spring the card back rather than leaving the box in its dismissed state:
-                // a LazyColumn item's state is restored under its key, so an entry brought back by
-                // Undo would otherwise reappear as an invisible, already-swiped row. What removes
-                // the row is the data — the DAO delete drops it from the Flow — not the box's own
-                // dismissal. Share has to spring back regardless, since sharing keeps the entry.
+                // Neither gesture removes the row by itself: share keeps the entry, and a delete
+                // is removed by the data — the DAO delete drops it from the Flow — so the card is
+                // always sent back to its resting position rather than left sitting dismissed.
                 coroutineScope.launch { dismissState.reset() }
             },
             content = {

--- a/app/src/main/kotlin/com/svenjacobs/app/leon/ui/screens/history/HistoryScreen.kt
+++ b/app/src/main/kotlin/com/svenjacobs/app/leon/ui/screens/history/HistoryScreen.kt
@@ -1,0 +1,314 @@
+/*
+ * Léon - The URL Cleaner
+ * Copyright (C) 2026 Sven Jacobs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.svenjacobs.app.leon.ui.screens.history
+
+import android.text.format.DateUtils
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboard
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.svenjacobs.app.leon.R
+import com.svenjacobs.app.leon.db.HistoryEntry
+import com.svenjacobs.app.leon.ui.common.copyToClipboard
+import com.svenjacobs.app.leon.ui.common.isDefaultBrowser
+import com.svenjacobs.app.leon.ui.common.openUrl
+import com.svenjacobs.app.leon.ui.common.shareText
+import com.svenjacobs.app.leon.ui.screens.history.model.HistoryScreenViewModel
+import com.svenjacobs.app.leon.ui.theme.AppTheme
+import com.svenjacobs.app.leon.ui.tooling.DayNightPreviews
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.launch
+
+@Composable
+fun HistoryScreen(
+    snackbarHostState: SnackbarHostState,
+    modifier: Modifier = Modifier,
+    viewModel: HistoryScreenViewModel = viewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    Content(
+        modifier = modifier,
+        isEnabled = uiState.isEnabled,
+        isCustomTabsEnabled = uiState.isCustomTabsEnabled,
+        entries = uiState.entries,
+        snackbarHostState = snackbarHostState,
+        onDeleteClick = viewModel::onDeleteClick,
+        onClearAllClick = viewModel::onClearAllClick,
+    )
+}
+
+@Composable
+private fun Content(
+    isEnabled: Boolean,
+    isCustomTabsEnabled: Boolean,
+    entries: ImmutableList<HistoryEntry>,
+    snackbarHostState: SnackbarHostState,
+    onDeleteClick: (String) -> Unit,
+    onClearAllClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var showClearAllDialog by rememberSaveable { mutableStateOf(false) }
+
+    if (showClearAllDialog) {
+        AlertDialog(
+            onDismissRequest = { showClearAllDialog = false },
+            text = { Text(stringResource(R.string.history_clear_all_confirm)) },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showClearAllDialog = false
+                        onClearAllClick()
+                    }
+                ) {
+                    Text(stringResource(R.string.history_clear_all))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showClearAllDialog = false }) {
+                    Text(stringResource(R.string.cancel))
+                }
+            },
+        )
+    }
+
+    Box(modifier = modifier.fillMaxSize().padding(16.dp)) {
+        when {
+            !isEnabled ->
+                EmptyState(modifier = Modifier.align(Alignment.Center)) {
+                    Text(
+                        text = stringResource(R.string.history_disabled_text),
+                        style = MaterialTheme.typography.bodyMedium,
+                        textAlign = TextAlign.Center,
+                    )
+                }
+
+            entries.isEmpty() ->
+                EmptyState(modifier = Modifier.align(Alignment.Center)) {
+                    Text(
+                        text = stringResource(R.string.history_empty_title),
+                        style = MaterialTheme.typography.headlineSmall,
+                        textAlign = TextAlign.Center,
+                    )
+                    Text(
+                        modifier = Modifier.padding(top = 8.dp),
+                        text = stringResource(R.string.history_empty_text),
+                        style = MaterialTheme.typography.bodyMedium,
+                        textAlign = TextAlign.Center,
+                    )
+                }
+
+            else ->
+                Column(modifier = Modifier.fillMaxSize()) {
+                    LazyColumn(modifier = Modifier.weight(1f).fillMaxWidth()) {
+                        items(entries, key = { it.id }) { entry ->
+                            HistoryRow(
+                                entry = entry,
+                                isCustomTabsEnabled = isCustomTabsEnabled,
+                                snackbarHostState = snackbarHostState,
+                                onDeleteClick = onDeleteClick,
+                                modifier = Modifier.padding(bottom = 8.dp),
+                            )
+                        }
+                    }
+
+                    OutlinedButton(
+                        modifier = Modifier.fillMaxWidth(),
+                        onClick = { showClearAllDialog = true },
+                    ) {
+                        Text(stringResource(R.string.history_clear_all))
+                    }
+                }
+        }
+    }
+}
+
+@Composable
+private fun EmptyState(modifier: Modifier = Modifier, content: @Composable () -> Unit) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        content()
+    }
+}
+
+@Composable
+private fun HistoryRow(
+    entry: HistoryEntry,
+    isCustomTabsEnabled: Boolean,
+    snackbarHostState: SnackbarHostState,
+    onDeleteClick: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val clipboard = LocalClipboard.current
+    val coroutineScope = rememberCoroutineScope()
+    val shareTitle = stringResource(R.string.share)
+    val openTitle = stringResource(R.string.open)
+    val clipboardMessage = stringResource(R.string.clipboard_message)
+    var menuFor by remember { mutableStateOf<String?>(null) }
+
+    Box(modifier = modifier) {
+        ElevatedCard(
+            modifier = Modifier.fillMaxWidth(),
+            onClick = { menuFor = entry.id },
+        ) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                Text(
+                    text = entry.url,
+                    style = MaterialTheme.typography.bodyMedium,
+                    maxLines = 3,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    modifier = Modifier.padding(top = 8.dp),
+                    text =
+                        DateUtils.formatDateTime(
+                            context,
+                            entry.at,
+                            DateUtils.FORMAT_SHOW_DATE or
+                                DateUtils.FORMAT_SHOW_TIME or
+                                DateUtils.FORMAT_ABBREV_ALL,
+                        ),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+
+        DropdownMenu(expanded = menuFor == entry.id, onDismissRequest = { menuFor = null }) {
+            DropdownMenuItem(
+                text = { Text(stringResource(R.string.share)) },
+                onClick = {
+                    menuFor = null
+                    shareText(context = context, text = entry.url, chooserTitle = shareTitle)
+                },
+            )
+
+            DropdownMenuItem(
+                text = { Text(stringResource(R.string.copy)) },
+                onClick = {
+                    menuFor = null
+                    coroutineScope.launch {
+                        copyToClipboard(
+                            clipboard = clipboard,
+                            snackbarHostState = snackbarHostState,
+                            text = entry.url,
+                            message = clipboardMessage,
+                        )
+                    }
+                },
+            )
+
+            DropdownMenuItem(
+                text = { Text(stringResource(R.string.open)) },
+                enabled = !isDefaultBrowser(context),
+                onClick = {
+                    menuFor = null
+                    openUrl(
+                        context = context,
+                        url = entry.url,
+                        customTabs = isCustomTabsEnabled,
+                        chooserTitle = openTitle,
+                    )
+                },
+            )
+
+            DropdownMenuItem(
+                text = { Text(stringResource(R.string.history_delete)) },
+                onClick = {
+                    menuFor = null
+                    onDeleteClick(entry.id)
+                },
+            )
+        }
+    }
+}
+
+@Composable
+@DayNightPreviews
+private fun ContentPreview() {
+    AppTheme {
+        Content(
+            isEnabled = true,
+            isCustomTabsEnabled = false,
+            entries =
+                persistentListOf(
+                    HistoryEntry(
+                        id = "1",
+                        url = "https://www.example.com/path?keep=123",
+                        at = System.currentTimeMillis(),
+                    ),
+                    HistoryEntry(
+                        id = "2",
+                        url = "https://www.example.org/another/path?keep=456",
+                        at = System.currentTimeMillis() - 3_600_000,
+                    ),
+                ),
+            snackbarHostState = remember { SnackbarHostState() },
+            onDeleteClick = {},
+            onClearAllClick = {},
+        )
+    }
+}
+
+@Composable
+@DayNightPreviews
+private fun ContentEmptyPreview() {
+    AppTheme {
+        Content(
+            isEnabled = true,
+            isCustomTabsEnabled = false,
+            entries = persistentListOf(),
+            snackbarHostState = remember { SnackbarHostState() },
+            onDeleteClick = {},
+            onClearAllClick = {},
+        )
+    }
+}

--- a/app/src/main/kotlin/com/svenjacobs/app/leon/ui/screens/history/HistoryScreen.kt
+++ b/app/src/main/kotlin/com/svenjacobs/app/leon/ui/screens/history/HistoryScreen.kt
@@ -18,22 +18,33 @@
 package com.svenjacobs.app.leon.ui.screens.history
 
 import android.text.format.DateUtils
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
+import androidx.compose.material3.SwipeToDismissBox
+import androidx.compose.material3.SwipeToDismissBoxValue
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -43,8 +54,12 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -79,6 +94,7 @@ fun HistoryScreen(
         entries = uiState.entries,
         snackbarHostState = snackbarHostState,
         onDeleteClick = viewModel::onDeleteClick,
+        onUndoDeleteClick = viewModel::onUndoDeleteClick,
         onClearAllClick = viewModel::onClearAllClick,
     )
 }
@@ -90,9 +106,13 @@ private fun Content(
     entries: ImmutableList<HistoryEntry>,
     snackbarHostState: SnackbarHostState,
     onDeleteClick: (String) -> Unit,
+    onUndoDeleteClick: (HistoryEntry) -> Unit,
     onClearAllClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val coroutineScope = rememberCoroutineScope()
+    val deletedMessage = stringResource(R.string.history_deleted)
+    val undoLabel = stringResource(R.string.undo)
     var showClearAllDialog by rememberSaveable { mutableStateOf(false) }
 
     if (showClearAllDialog) {
@@ -151,8 +171,21 @@ private fun Content(
                                 entry = entry,
                                 isCustomTabsEnabled = isCustomTabsEnabled,
                                 snackbarHostState = snackbarHostState,
-                                onDeleteClick = onDeleteClick,
-                                modifier = Modifier.padding(bottom = 8.dp),
+                                onDelete = { deleted ->
+                                    coroutineScope.launch {
+                                        onDeleteClick(deleted.id)
+                                        val result =
+                                            snackbarHostState.showSnackbar(
+                                                message = deletedMessage,
+                                                actionLabel = undoLabel,
+                                                duration = SnackbarDuration.Short,
+                                            )
+                                        if (result == SnackbarResult.ActionPerformed) {
+                                            onUndoDeleteClick(deleted)
+                                        }
+                                    }
+                                },
+                                modifier = Modifier.padding(bottom = 8.dp).animateItem(),
                             )
                         }
                     }
@@ -183,44 +216,75 @@ private fun HistoryRow(
     entry: HistoryEntry,
     isCustomTabsEnabled: Boolean,
     snackbarHostState: SnackbarHostState,
-    onDeleteClick: (String) -> Unit,
+    onDelete: (HistoryEntry) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
     val clipboard = LocalClipboard.current
+    val haptics = LocalHapticFeedback.current
     val coroutineScope = rememberCoroutineScope()
     val shareTitle = stringResource(R.string.share)
     val openTitle = stringResource(R.string.open)
     val clipboardMessage = stringResource(R.string.clipboard_message)
     var menuFor by remember { mutableStateOf<String?>(null) }
 
+    val dismissState = rememberSwipeToDismissBoxState()
+
     Box(modifier = modifier) {
-        ElevatedCard(
-            modifier = Modifier.fillMaxWidth(),
-            onClick = { menuFor = entry.id },
-        ) {
-            Column(modifier = Modifier.padding(16.dp)) {
-                Text(
-                    text = entry.url,
-                    style = MaterialTheme.typography.bodyMedium,
-                    maxLines = 3,
-                    overflow = TextOverflow.Ellipsis,
-                )
-                Text(
-                    modifier = Modifier.padding(top = 8.dp),
-                    text =
-                        DateUtils.formatDateTime(
-                            context,
-                            entry.at,
-                            DateUtils.FORMAT_SHOW_DATE or
-                                DateUtils.FORMAT_SHOW_TIME or
-                                DateUtils.FORMAT_ABBREV_ALL,
-                        ),
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-        }
+        SwipeToDismissBox(
+            state = dismissState,
+            backgroundContent = { SwipeBackground(dismissState.dismissDirection) },
+            onDismiss = { value ->
+                when (value) {
+                    SwipeToDismissBoxValue.StartToEnd -> {
+                        haptics.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                        shareText(context = context, text = entry.url, chooserTitle = shareTitle)
+                    }
+
+                    SwipeToDismissBoxValue.EndToStart -> {
+                        haptics.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                        onDelete(entry)
+                    }
+
+                    SwipeToDismissBoxValue.Settled -> {}
+                }
+
+                // Always spring the card back rather than leaving the box in its dismissed state:
+                // a LazyColumn item's state is restored under its key, so an entry brought back by
+                // Undo would otherwise reappear as an invisible, already-swiped row. What removes
+                // the row is the data — the DAO delete drops it from the Flow — not the box's own
+                // dismissal. Share has to spring back regardless, since sharing keeps the entry.
+                coroutineScope.launch { dismissState.reset() }
+            },
+            content = {
+                ElevatedCard(
+                    modifier = Modifier.fillMaxWidth(),
+                    onClick = { menuFor = entry.id },
+                ) {
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        Text(
+                            text = entry.url,
+                            style = MaterialTheme.typography.bodyMedium,
+                            maxLines = 3,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                        Text(
+                            modifier = Modifier.padding(top = 8.dp),
+                            text =
+                                DateUtils.formatDateTime(
+                                    context,
+                                    entry.at,
+                                    DateUtils.FORMAT_SHOW_DATE or
+                                        DateUtils.FORMAT_SHOW_TIME or
+                                        DateUtils.FORMAT_ABBREV_ALL,
+                                ),
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            },
+        )
 
         DropdownMenu(expanded = menuFor == entry.id, onDismissRequest = { menuFor = null }) {
             DropdownMenuItem(
@@ -264,9 +328,56 @@ private fun HistoryRow(
                 text = { Text(stringResource(R.string.history_delete)) },
                 onClick = {
                     menuFor = null
-                    onDeleteClick(entry.id)
+                    onDelete(entry)
                 },
             )
+        }
+    }
+}
+
+@Composable
+private fun SwipeBackground(direction: SwipeToDismissBoxValue) {
+    val color: Color
+    val icon: ImageVector?
+    val alignment: Alignment
+    val tint: Color
+    val description: String?
+
+    when (direction) {
+        SwipeToDismissBoxValue.StartToEnd -> {
+            color = MaterialTheme.colorScheme.primaryContainer
+            icon = Icons.Default.Share
+            alignment = Alignment.CenterStart
+            tint = MaterialTheme.colorScheme.onPrimaryContainer
+            description = stringResource(R.string.share)
+        }
+
+        SwipeToDismissBoxValue.EndToStart -> {
+            color = MaterialTheme.colorScheme.errorContainer
+            icon = Icons.Default.Delete
+            alignment = Alignment.CenterEnd
+            tint = MaterialTheme.colorScheme.onErrorContainer
+            description = stringResource(R.string.history_delete)
+        }
+
+        SwipeToDismissBoxValue.Settled -> {
+            color = Color.Transparent
+            icon = null
+            alignment = Alignment.Center
+            tint = Color.Unspecified
+            description = null
+        }
+    }
+
+    Box(
+        modifier =
+            Modifier.fillMaxSize()
+                .background(color = color, shape = MaterialTheme.shapes.medium)
+                .padding(horizontal = 20.dp),
+        contentAlignment = alignment,
+    ) {
+        if (icon != null) {
+            Icon(imageVector = icon, contentDescription = description, tint = tint)
         }
     }
 }
@@ -293,6 +404,7 @@ private fun ContentPreview() {
                 ),
             snackbarHostState = remember { SnackbarHostState() },
             onDeleteClick = {},
+            onUndoDeleteClick = {},
             onClearAllClick = {},
         )
     }
@@ -308,7 +420,23 @@ private fun ContentEmptyPreview() {
             entries = persistentListOf(),
             snackbarHostState = remember { SnackbarHostState() },
             onDeleteClick = {},
+            onUndoDeleteClick = {},
             onClearAllClick = {},
         )
+    }
+}
+
+@Composable
+@DayNightPreviews
+private fun SwipeBackgroundPreview() {
+    AppTheme {
+        Column {
+            Box(modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp).height(80.dp)) {
+                SwipeBackground(SwipeToDismissBoxValue.StartToEnd)
+            }
+            Box(modifier = Modifier.fillMaxWidth().height(80.dp)) {
+                SwipeBackground(SwipeToDismissBoxValue.EndToStart)
+            }
+        }
     }
 }

--- a/app/src/main/kotlin/com/svenjacobs/app/leon/ui/screens/history/model/HistoryScreenViewModel.kt
+++ b/app/src/main/kotlin/com/svenjacobs/app/leon/ui/screens/history/model/HistoryScreenViewModel.kt
@@ -1,0 +1,72 @@
+/*
+ * Léon - The URL Cleaner
+ * Copyright (C) 2026 Sven Jacobs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.svenjacobs.app.leon.ui.screens.history.model
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.svenjacobs.app.leon.datastore.AppDataStoreManager
+import com.svenjacobs.app.leon.db.HistoryDao
+import com.svenjacobs.app.leon.db.HistoryEntry
+import com.svenjacobs.app.leon.inject.AppContainer.AppDataStoreManager
+import com.svenjacobs.app.leon.inject.AppContainer.HistoryDao
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+class HistoryScreenViewModel(
+    private val appDataStoreManager: AppDataStoreManager = AppDataStoreManager,
+    private val historyDao: HistoryDao = HistoryDao,
+) : ViewModel() {
+
+    data class UiState(
+        val isEnabled: Boolean = true,
+        val isCustomTabsEnabled: Boolean = false,
+        val entries: ImmutableList<HistoryEntry> = persistentListOf(),
+    )
+
+    val uiState: StateFlow<UiState> =
+        combine(
+                appDataStoreManager.historyEnabled,
+                appDataStoreManager.customTabsEnabled,
+                historyDao.entries(),
+            ) { isEnabled, isCustomTabsEnabled, entries ->
+                UiState(
+                    isEnabled = isEnabled,
+                    isCustomTabsEnabled = isCustomTabsEnabled,
+                    entries = entries.toImmutableList(),
+                )
+            }
+            .stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(5_000),
+                initialValue = UiState(),
+            )
+
+    fun onDeleteClick(id: String) {
+        viewModelScope.launch { historyDao.delete(id) }
+    }
+
+    fun onClearAllClick() {
+        viewModelScope.launch { historyDao.clear() }
+    }
+}

--- a/app/src/main/kotlin/com/svenjacobs/app/leon/ui/screens/history/model/HistoryScreenViewModel.kt
+++ b/app/src/main/kotlin/com/svenjacobs/app/leon/ui/screens/history/model/HistoryScreenViewModel.kt
@@ -66,6 +66,11 @@ class HistoryScreenViewModel(
         viewModelScope.launch { historyDao.delete(id) }
     }
 
+    /** Puts a swiped-away entry back, timestamp and all, so it returns to the position it had. */
+    fun onUndoDeleteClick(entry: HistoryEntry) {
+        viewModelScope.launch { historyDao.record(id = entry.id, url = entry.url, at = entry.at) }
+    }
+
     fun onClearAllClick() {
         viewModelScope.launch { historyDao.clear() }
     }

--- a/app/src/main/kotlin/com/svenjacobs/app/leon/ui/screens/main/MainScreen.kt
+++ b/app/src/main/kotlin/com/svenjacobs/app/leon/ui/screens/main/MainScreen.kt
@@ -18,13 +18,9 @@
 package com.svenjacobs.app.leon.ui.screens.main
 
 import android.app.Activity
-import android.content.ClipData
 import android.content.Context
 import android.content.ContextWrapper
-import android.content.Intent
-import android.net.Uri
 import android.view.Window
-import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
@@ -78,13 +74,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
-import androidx.compose.ui.platform.toClipEntry
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.core.net.toUri
 import androidx.core.view.WindowCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -95,9 +89,13 @@ import androidx.navigation.compose.rememberNavController
 import androidx.window.core.layout.WindowSizeClass
 import com.svenjacobs.app.leon.R
 import com.svenjacobs.app.leon.core.domain.action.ActionAfterClean
+import com.svenjacobs.app.leon.ui.common.copyToClipboard
 import com.svenjacobs.app.leon.ui.common.isDefaultBrowser
+import com.svenjacobs.app.leon.ui.common.openUrl
+import com.svenjacobs.app.leon.ui.common.shareText
 import com.svenjacobs.app.leon.ui.common.views.TopAppBar
 import com.svenjacobs.app.leon.ui.model.SourceText
+import com.svenjacobs.app.leon.ui.screens.history.HistoryScreen
 import com.svenjacobs.app.leon.ui.screens.main.model.MainScreenViewModel
 import com.svenjacobs.app.leon.ui.screens.main.model.MainScreenViewModel.UiState.ChangeRow
 import com.svenjacobs.app.leon.ui.screens.main.model.MainScreenViewModel.UiState.Result
@@ -157,53 +155,27 @@ fun MainScreen(
     }
 
     fun openShareMenu(result: Result.Success) {
-        val intent =
-            Intent(Intent.ACTION_SEND).apply {
-                type = "text/plain"
-                addCategory(Intent.CATEGORY_DEFAULT)
-                putExtra(Intent.EXTRA_TEXT, result.cleanedText)
-            }
-
-        context.startActivity(Intent.createChooser(intent, shareTitle))
-    }
-
-    fun openInDefaultApp(result: Result.Success) {
-        val uri =
-            result.urls.firstOrNull()?.let { url -> runCatching { Uri.parse(url) }.getOrNull() }
-                ?: return
-
-        val intent = Intent(Intent.ACTION_VIEW, uri)
-
-        context.startActivity(Intent.createChooser(intent, openTitle))
-    }
-
-    fun openInCustomTabs(result: Result.Success) {
-        result.urls.firstOrNull()?.let { url ->
-            val intent =
-                CustomTabsIntent.Builder()
-                    .setColorScheme(CustomTabsIntent.COLOR_SCHEME_SYSTEM)
-                    .build()
-
-            intent.launchUrl(context, url.toUri())
-        }
+        shareText(context = context, text = result.cleanedText, chooserTitle = shareTitle)
     }
 
     fun openUrl(result: Result.Success) {
-        // When Leon is the system default browser we neither can open the URL in custom tabs nor
-        // in the default browser because this would just open Leon again.
-        if (isDefaultBrowser(context)) return
-
-        if (uiState.isCustomTabsEnabled) {
-            openInCustomTabs(result)
-        } else {
-            openInDefaultApp(result)
-        }
+        val url = result.urls.firstOrNull() ?: return
+        openUrl(
+            context = context,
+            url = url,
+            customTabs = uiState.isCustomTabsEnabled,
+            chooserTitle = openTitle,
+        )
     }
 
     fun copyToClipboard(text: String) {
         coroutineScope.launch {
-            clipboard.setClipEntry(ClipData.newPlainText(text, text).toClipEntry())
-            snackbarHostState.showSnackbar(copiedToClipboardMessage)
+            copyToClipboard(
+                clipboard = clipboard,
+                snackbarHostState = snackbarHostState,
+                text = text,
+                message = copiedToClipboardMessage,
+            )
         }
     }
 
@@ -282,6 +254,10 @@ fun MainScreen(
                             onExtractUrlCheckedChange = viewModel::onExtractUrlCheckedChange,
                             onChangeToggled = viewModel::onChangeToggled,
                         )
+                    }
+
+                    composable(Screen.History.route) {
+                        HistoryScreen(snackbarHostState = snackbarHostState)
                     }
 
                     composable(Screen.Settings.route) {

--- a/app/src/main/kotlin/com/svenjacobs/app/leon/ui/screens/main/model/MainScreenViewModel.kt
+++ b/app/src/main/kotlin/com/svenjacobs/app/leon/ui/screens/main/model/MainScreenViewModel.kt
@@ -25,7 +25,9 @@ import com.svenjacobs.app.leon.core.domain.change.Change
 import com.svenjacobs.app.leon.core.domain.sanitizer.SanitizerId
 import com.svenjacobs.app.leon.core.domain.url.Url
 import com.svenjacobs.app.leon.datastore.AppDataStoreManager
+import com.svenjacobs.app.leon.db.HistoryDao
 import com.svenjacobs.app.leon.inject.AppContainer.AppDataStoreManager
+import com.svenjacobs.app.leon.inject.AppContainer.HistoryDao
 import com.svenjacobs.app.leon.ui.screens.main.model.MainScreenViewModel.UiState.ChangeRow
 import com.svenjacobs.app.leon.ui.screens.main.model.MainScreenViewModel.UiState.Result
 import java.util.UUID
@@ -43,6 +45,7 @@ import kotlinx.coroutines.launch
 class MainScreenViewModel(
     private val appDataStoreManager: AppDataStoreManager = AppDataStoreManager,
     private val cleaner: Cleaner = Cleaner(),
+    private val historyDao: HistoryDao = HistoryDao,
 ) : ViewModel() {
 
     data class UiState(
@@ -117,6 +120,26 @@ class MainScreenViewModel(
     /** Id of the input for which the action after clean has already been performed. */
     private var handledActionInputId: String? = null
 
+    /** The (inputId, url) pair last recorded, so an unchanged one is not written again. */
+    private var recorded: Pair<String, String>? = null
+
+    /**
+     * Records [url], cleaned from the input [id], to the history.
+     *
+     * The outer [combine] re-emits on every DataStore tick and again on resubscribe after a
+     * configuration change, even though nothing about the cleaned URL actually changed — so this is
+     * called far more often than the URL itself changes. [recorded] guards against turning those
+     * re-emissions into duplicate or reverted history rows.
+     */
+    private fun record(id: String, url: String) {
+        if (recorded == (id to url)) return
+        recorded = id to url
+        viewModelScope.launch {
+            if (!appDataStoreManager.historyEnabled.first()) return@launch
+            historyDao.record(id = id, url = url, at = System.currentTimeMillis())
+        }
+    }
+
     /**
      * The input, the user's selection and the auto-reset deadline for that same input, combined
      * ahead of the outer [combine] so that it stays within its five-flow limit.
@@ -167,6 +190,10 @@ class MainScreenViewModel(
                             selection = session.selection,
                         )
                     } ?: Result.Empty
+
+                if (input != null && result is Result.Success && result.urls.isNotEmpty()) {
+                    record(input.id, result.urls.first())
+                }
 
                 UiState(
                     isLoading = input == null,

--- a/app/src/main/kotlin/com/svenjacobs/app/leon/ui/screens/main/model/Screen.kt
+++ b/app/src/main/kotlin/com/svenjacobs/app/leon/ui/screens/main/model/Screen.kt
@@ -19,6 +19,7 @@ package com.svenjacobs.app.leon.ui.screens.main.model
 
 import androidx.annotation.StringRes
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -36,6 +37,14 @@ sealed class Screen(
             icon = Icons.Filled.Home,
             label = R.string.screen_main,
             iconContentDescription = R.string.screen_main,
+        )
+
+    data object History :
+        Screen(
+            route = "history",
+            icon = Icons.Filled.History,
+            label = R.string.screen_history,
+            iconContentDescription = R.string.screen_history,
         )
 
     data object Settings :

--- a/app/src/main/kotlin/com/svenjacobs/app/leon/ui/screens/main/views/BottomBar.kt
+++ b/app/src/main/kotlin/com/svenjacobs/app/leon/ui/screens/main/views/BottomBar.kt
@@ -34,7 +34,7 @@ import com.svenjacobs.app.leon.ui.screens.main.model.Screen
 
 @Composable
 internal fun BottomBar(navController: NavHostController, modifier: Modifier = Modifier) {
-    val bottomNavItems = listOf(Screen.Main, Screen.Settings)
+    val bottomNavItems = listOf(Screen.Main, Screen.History, Screen.Settings)
 
     NavigationBar(modifier = modifier) {
         val navBackStackEntry by navController.currentBackStackEntryAsState()

--- a/app/src/main/kotlin/com/svenjacobs/app/leon/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/svenjacobs/app/leon/ui/screens/settings/SettingsScreen.kt
@@ -69,6 +69,7 @@ fun SettingsScreen(
         browserEnabled = uiState.browserEnabled,
         customTabsEnabled = uiState.customTabsEnabled,
         protectScreenEnabled = uiState.protectScreenEnabled,
+        historyEnabled = uiState.historyEnabled,
         actionAfterClean = uiState.actionAfterClean,
         autoReset = uiState.autoReset,
         onSanitizersClick = onNavigateToSettingsSanitizers,
@@ -76,6 +77,7 @@ fun SettingsScreen(
         onBrowserSwitchCheckedChange = viewModel::onBrowserSwitchCheckedChange,
         onCustomTabsSwitchCheckedChange = viewModel::onCustomTabsSwitchCheckedChange,
         onProtectScreenSwitchCheckedChange = viewModel::onProtectScreenSwitchCheckedChange,
+        onHistorySwitchCheckedChange = viewModel::onHistorySwitchCheckedChange,
         onActionAfterCleanClick = viewModel::onActionAfterCleanClick,
         onAutoResetClick = viewModel::onAutoResetClick,
     )
@@ -87,6 +89,7 @@ private fun Content(
     browserEnabled: Boolean,
     customTabsEnabled: Boolean,
     protectScreenEnabled: Boolean,
+    historyEnabled: Boolean,
     actionAfterClean: ActionAfterClean,
     autoReset: AutoReset,
     onSanitizersClick: () -> Unit,
@@ -94,6 +97,7 @@ private fun Content(
     onBrowserSwitchCheckedChange: (Boolean) -> Unit,
     onCustomTabsSwitchCheckedChange: (Boolean) -> Unit,
     onProtectScreenSwitchCheckedChange: (Boolean) -> Unit,
+    onHistorySwitchCheckedChange: (Boolean) -> Unit,
     onActionAfterCleanClick: (ActionAfterClean) -> Unit,
     onAutoResetClick: (AutoReset) -> Unit,
     modifier: Modifier = Modifier,
@@ -128,6 +132,13 @@ private fun Content(
                     text = stringResource(R.string.protect_screen),
                     checked = protectScreenEnabled,
                     onCheckedChange = onProtectScreenSwitchCheckedChange,
+                )
+
+                SwitchRow(
+                    modifier = Modifier.padding(top = 16.dp),
+                    text = stringResource(R.string.history_enabled),
+                    checked = historyEnabled,
+                    onCheckedChange = onHistorySwitchCheckedChange,
                 )
 
                 Column(modifier = Modifier.padding(top = 8.dp)) {
@@ -343,6 +354,7 @@ private fun ContentPreview() {
             browserEnabled = false,
             customTabsEnabled = false,
             protectScreenEnabled = false,
+            historyEnabled = true,
             actionAfterClean = ActionAfterClean.OpenShareMenu,
             autoReset = AutoReset.Off,
             onSanitizersClick = {},
@@ -350,6 +362,7 @@ private fun ContentPreview() {
             onBrowserSwitchCheckedChange = {},
             onCustomTabsSwitchCheckedChange = {},
             onProtectScreenSwitchCheckedChange = {},
+            onHistorySwitchCheckedChange = {},
             onActionAfterCleanClick = {},
             onAutoResetClick = {},
         )

--- a/app/src/main/kotlin/com/svenjacobs/app/leon/ui/screens/settings/model/SettingsScreenViewModel.kt
+++ b/app/src/main/kotlin/com/svenjacobs/app/leon/ui/screens/settings/model/SettingsScreenViewModel.kt
@@ -25,8 +25,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.svenjacobs.app.leon.core.domain.action.ActionAfterClean
 import com.svenjacobs.app.leon.datastore.AppDataStoreManager
+import com.svenjacobs.app.leon.db.HistoryDao
 import com.svenjacobs.app.leon.inject.AppContainer.AppContext
 import com.svenjacobs.app.leon.inject.AppContainer.AppDataStoreManager
+import com.svenjacobs.app.leon.inject.AppContainer.HistoryDao
 import com.svenjacobs.app.leon.ui.model.AutoReset
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -39,6 +41,7 @@ import kotlinx.coroutines.launch
 class SettingsScreenViewModel(
     private val context: Context = AppContext,
     private val appDataStoreManager: AppDataStoreManager = AppDataStoreManager,
+    private val historyDao: HistoryDao = HistoryDao,
 ) : ViewModel() {
 
     data class UiState(
@@ -46,26 +49,37 @@ class SettingsScreenViewModel(
         val browserEnabled: Boolean = false,
         val customTabsEnabled: Boolean = false,
         val protectScreenEnabled: Boolean = false,
+        val historyEnabled: Boolean = true,
         val actionAfterClean: ActionAfterClean = ActionAfterClean.DoNothing,
         val autoReset: AutoReset = AutoReset.Off,
     )
 
     private val browserEnabled = MutableStateFlow(false)
 
+    /**
+     * The browser and history switches, combined ahead of the outer [combine] so that it stays
+     * within its five-flow limit.
+     */
+    private data class Toggles(val browserEnabled: Boolean, val historyEnabled: Boolean)
+
     val uiState: StateFlow<UiState> =
         combine(
-                browserEnabled,
+                combine(browserEnabled, appDataStoreManager.historyEnabled) {
+                    browserEnabled,
+                    historyEnabled ->
+                    Toggles(browserEnabled, historyEnabled)
+                },
                 appDataStoreManager.customTabsEnabled,
                 appDataStoreManager.protectScreenEnabled,
                 appDataStoreManager.actionAfterClean,
                 appDataStoreManager.autoReset,
-            ) { browserEnabled, customTabsEnabled, protectScreenEnabled, actionAfterClean, autoReset
-                ->
+            ) { toggles, customTabsEnabled, protectScreenEnabled, actionAfterClean, autoReset ->
                 UiState(
                     isLoading = false,
-                    browserEnabled = browserEnabled,
+                    browserEnabled = toggles.browserEnabled,
                     customTabsEnabled = customTabsEnabled,
                     protectScreenEnabled = protectScreenEnabled,
+                    historyEnabled = toggles.historyEnabled,
                     actionAfterClean = actionAfterClean ?: ActionAfterClean.DoNothing,
                     autoReset = autoReset ?: AutoReset.Off,
                 )
@@ -100,6 +114,14 @@ class SettingsScreenViewModel(
 
     fun onProtectScreenSwitchCheckedChange(checked: Boolean) {
         viewModelScope.launch { appDataStoreManager.setProtectScreenEnabled(checked) }
+    }
+
+    fun onHistorySwitchCheckedChange(checked: Boolean) {
+        viewModelScope.launch {
+            appDataStoreManager.setHistoryEnabled(checked)
+            // Turning the history off must leave nothing behind.
+            if (!checked) historyDao.clear()
+        }
     }
 
     fun onActionAfterCleanClick(actionAfterClean: ActionAfterClean) {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -19,6 +19,7 @@
 <resources>
     <string name="screen_main">Start</string>
     <string name="screen_settings">Einstellungen</string>
+    <string name="screen_history">Verlauf</string>
     <string name="scaffold_title">Léon – Der URL Cleaner</string>
     <string name="share">Teilen</string>
     <string name="open">Öffnen</string>
@@ -50,6 +51,14 @@
     <string name="auto_reset_after">Automatisch zurücksetzen nach</string>
     <string name="auto_reset_off">Aus</string>
     <string name="auto_reset_minutes">%1$d Min.</string>
+    <string name="history_enabled">Verlauf bereinigter URLs speichern</string>
+    <string name="history_empty_title">Hier ist noch nichts</string>
+    <string name="history_empty_text">Bereinigte URLs erscheinen hier, damit du sie später erneut teilen, kopieren oder öffnen kannst. Die letzten zehn werden gespeichert.</string>
+    <string name="history_disabled_text">Der Verlauf ist deaktiviert. Aktiviere ihn in den Einstellungen, um die letzten zehn bereinigten URLs zu speichern.</string>
+    <string name="history_clear_all">Verlauf löschen</string>
+    <string name="history_clear_all_confirm">Alle Einträge aus dem Verlauf entfernen?</string>
+    <string name="history_delete">Löschen</string>
+    <string name="cancel">Abbrechen</string>
     <string name="process_text_action_name">URL säubern (Léon)</string>
     <string name="protect_screen">App-Bildschirm schützen</string>
     <string name="about">Über</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -58,6 +58,8 @@
     <string name="history_clear_all">Verlauf löschen</string>
     <string name="history_clear_all_confirm">Alle Einträge aus dem Verlauf entfernen?</string>
     <string name="history_delete">Löschen</string>
+    <string name="history_deleted">Eintrag gelöscht</string>
+    <string name="undo">Rückgängig</string>
     <string name="cancel">Abbrechen</string>
     <string name="process_text_action_name">URL säubern (Léon)</string>
     <string name="protect_screen">App-Bildschirm schützen</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -58,6 +58,8 @@
     <string name="history_clear_all">履歴を消去</string>
     <string name="history_clear_all_confirm">履歴からすべての項目を削除しますか？</string>
     <string name="history_delete">削除</string>
+    <string name="history_deleted">項目を削除しました</string>
+    <string name="undo">元に戻す</string>
     <string name="cancel">キャンセル</string>
     <string name="process_text_action_name">URL をクリーン (Léon)</string>
     <string name="protect_screen">アプリ画面を保護</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -19,6 +19,7 @@
 <resources>
     <string name="screen_main">ホーム</string>
     <string name="screen_settings">設定</string>
+    <string name="screen_history">履歴</string>
     <string name="scaffold_title">Léon – URL クリーナー</string>
     <string name="share">共有</string>
     <string name="open">開く</string>
@@ -50,6 +51,14 @@
     <string name="auto_reset_after">自動リセットまでの時間</string>
     <string name="auto_reset_off">オフ</string>
     <string name="auto_reset_minutes">%1$d 分</string>
+    <string name="history_enabled">クリーンした URL の履歴を保存する</string>
+    <string name="history_empty_title">まだ何もありません</string>
+    <string name="history_empty_text">クリーンした URL がここに表示され、後で共有、コピー、または開くことができます。最新10件が保存されます。</string>
+    <string name="history_disabled_text">履歴はオフになっています。設定でオンにすると、クリーンした URL の最新10件が保存されます。</string>
+    <string name="history_clear_all">履歴を消去</string>
+    <string name="history_clear_all_confirm">履歴からすべての項目を削除しますか？</string>
+    <string name="history_delete">削除</string>
+    <string name="cancel">キャンセル</string>
     <string name="process_text_action_name">URL をクリーン (Léon)</string>
     <string name="protect_screen">アプリ画面を保護</string>
     <string name="about">アプリについて</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -19,6 +19,7 @@
 <resources>
     <string name="screen_main">Ekran główny</string>
     <string name="screen_settings">Ustawienia</string>
+    <string name="screen_history">Historia</string>
     <string name="scaffold_title">Léon – Oczyszczacz URL</string>
     <string name="share">Udostępnij</string>
     <string name="open">Otwórz</string>
@@ -50,6 +51,14 @@
     <string name="auto_reset_after">Automatyczne zerowanie po</string>
     <string name="auto_reset_off">Wyłączone</string>
     <string name="auto_reset_minutes">%1$d min</string>
+    <string name="history_enabled">Zachowuj historię wyczyszczonych adresów URL</string>
+    <string name="history_empty_title">Nic tu jeszcze nie ma</string>
+    <string name="history_empty_text">Wyczyszczone adresy URL pojawiają się tutaj, dzięki czemu możesz je później udostępnić, skopiować lub otworzyć ponownie. Zachowywanych jest ostatnich dziesięć.</string>
+    <string name="history_disabled_text">Historia jest wyłączona. Włącz ją w ustawieniach, aby zachowywać ostatnie dziesięć wyczyszczonych adresów URL.</string>
+    <string name="history_clear_all">Wyczyść historię</string>
+    <string name="history_clear_all_confirm">Usunąć wszystkie wpisy z historii?</string>
+    <string name="history_delete">Usuń</string>
+    <string name="cancel">Anuluj</string>
     <string name="process_text_action_name">Wyczyść URL (Léon)</string>
     <string name="protect_screen">Chroń ekran aplikacji</string>
     <string name="about">O aplikacji</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -58,6 +58,8 @@
     <string name="history_clear_all">Wyczyść historię</string>
     <string name="history_clear_all_confirm">Usunąć wszystkie wpisy z historii?</string>
     <string name="history_delete">Usuń</string>
+    <string name="history_deleted">Wpis usunięty</string>
+    <string name="undo">Cofnij</string>
     <string name="cancel">Anuluj</string>
     <string name="process_text_action_name">Wyczyść URL (Léon)</string>
     <string name="protect_screen">Chroń ekran aplikacji</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -58,6 +58,8 @@
     <string name="history_clear_all">Очистить историю</string>
     <string name="history_clear_all_confirm">Удалить все записи из истории?</string>
     <string name="history_delete">Удалить</string>
+    <string name="history_deleted">Запись удалена</string>
+    <string name="undo">Отменить</string>
     <string name="cancel">Отмена</string>
     <string name="process_text_action_name">Очистить URL (Léon)</string>
     <string name="protect_screen">Защитить экран приложения</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -19,6 +19,7 @@
 <resources>
     <string name="screen_main">Дом</string>
     <string name="screen_settings">Настройки</string>
+    <string name="screen_history">История</string>
     <string name="scaffold_title">Léon – Очиститель URL</string>
     <string name="share">Поделиться</string>
     <string name="open">Открыть</string>
@@ -50,6 +51,14 @@
     <string name="auto_reset_after">Автосброс через</string>
     <string name="auto_reset_off">Выкл.</string>
     <string name="auto_reset_minutes">%1$d мин</string>
+    <string name="history_enabled">Сохранять историю очищенных URL-адресов</string>
+    <string name="history_empty_title">Здесь пока пусто</string>
+    <string name="history_empty_text">Очищенные вами URL-адреса появляются здесь, чтобы вы могли позже поделиться ими, скопировать или открыть их снова. Хранятся последние десять.</string>
+    <string name="history_disabled_text">История отключена. Включите её в настройках, чтобы сохранять последние десять очищенных URL-адресов.</string>
+    <string name="history_clear_all">Очистить историю</string>
+    <string name="history_clear_all_confirm">Удалить все записи из истории?</string>
+    <string name="history_delete">Удалить</string>
+    <string name="cancel">Отмена</string>
     <string name="process_text_action_name">Очистить URL (Léon)</string>
     <string name="protect_screen">Защитить экран приложения</string>
     <string name="about">О программе</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -19,6 +19,7 @@
 <resources>
     <string name="screen_main">Trang chủ</string>
     <string name="screen_settings">Thiết đặt</string>
+    <string name="screen_history">Lịch sử</string>
     <string name="scaffold_title">Léon – Trình dọn dẹp URL</string>
     <string name="share">Chia sẻ</string>
     <string name="open">Mở</string>
@@ -50,6 +51,14 @@
     <string name="auto_reset_after">Tự động đặt lại sau</string>
     <string name="auto_reset_off">Tắt</string>
     <string name="auto_reset_minutes">%1$d phút</string>
+    <string name="history_enabled">Lưu lịch sử URL đã làm sạch</string>
+    <string name="history_empty_title">Chưa có gì ở đây</string>
+    <string name="history_empty_text">Các URL bạn làm sạch sẽ xuất hiện ở đây, để bạn có thể chia sẻ, sao chép hoặc mở lại sau này. Mười mục gần nhất được lưu giữ.</string>
+    <string name="history_disabled_text">Lịch sử đang tắt. Hãy bật trong phần thiết đặt để lưu mười URL đã làm sạch gần nhất.</string>
+    <string name="history_clear_all">Xóa lịch sử</string>
+    <string name="history_clear_all_confirm">Xóa tất cả mục trong lịch sử?</string>
+    <string name="history_delete">Xóa</string>
+    <string name="cancel">Hủy</string>
     <string name="process_text_action_name">Làm sạch URL (Léon)</string>
     <string name="protect_screen">Bảo vệ màn hình ứng dụng</string>
     <string name="about">Thông tin</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -58,6 +58,8 @@
     <string name="history_clear_all">Xóa lịch sử</string>
     <string name="history_clear_all_confirm">Xóa tất cả mục trong lịch sử?</string>
     <string name="history_delete">Xóa</string>
+    <string name="history_deleted">Đã xóa mục</string>
+    <string name="undo">Hoàn tác</string>
     <string name="cancel">Hủy</string>
     <string name="process_text_action_name">Làm sạch URL (Léon)</string>
     <string name="protect_screen">Bảo vệ màn hình ứng dụng</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -59,6 +59,8 @@
     <string name="history_clear_all">清空历史记录</string>
     <string name="history_clear_all_confirm">确定要删除历史记录中的所有条目吗？</string>
     <string name="history_delete">删除</string>
+    <string name="history_deleted">条目已删除</string>
+    <string name="undo">撤销</string>
     <string name="cancel">取消</string>
     <string name="process_text_action_name">链接清理 (Léon)</string>
     <string name="protect_screen">应用截屏保护</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -20,6 +20,7 @@
     <string name="app_name" translatable="false">URL 清理器</string>
     <string name="screen_main">首页</string>
     <string name="screen_settings">设置</string>
+    <string name="screen_history">历史记录</string>
     <string name="scaffold_title">Léon – 链接清理器</string>
     <string name="share">分享</string>
     <string name="open">打开</string>
@@ -51,6 +52,14 @@
     <string name="auto_reset_after">自动重置延时</string>
     <string name="auto_reset_off">关闭</string>
     <string name="auto_reset_minutes">%1$d 分钟</string>
+    <string name="history_enabled">保留已清理链接的历史记录</string>
+    <string name="history_empty_title">暂无内容</string>
+    <string name="history_empty_text">你清理过的链接会显示在这里，方便你之后再次分享、复制或打开。最多保留最近十条。</string>
+    <string name="history_disabled_text">历史记录功能已关闭。在设置中开启后，将保留最近清理的十条链接。</string>
+    <string name="history_clear_all">清空历史记录</string>
+    <string name="history_clear_all_confirm">确定要删除历史记录中的所有条目吗？</string>
+    <string name="history_delete">删除</string>
+    <string name="cancel">取消</string>
     <string name="process_text_action_name">链接清理 (Léon)</string>
     <string name="protect_screen">应用截屏保护</string>
     <string name="about">关于</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -59,6 +59,8 @@
     <string name="history_clear_all">Clear history</string>
     <string name="history_clear_all_confirm">Remove all entries from the history?</string>
     <string name="history_delete">Delete</string>
+    <string name="history_deleted">Entry deleted</string>
+    <string name="undo">Undo</string>
     <string name="cancel">Cancel</string>
     <string name="process_text_action_name">Clean URL (Léon)</string>
     <string name="protect_screen">Protect app screen</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,6 +20,7 @@
     <string name="app_name" translatable="false">URL Cleaner</string>
     <string name="screen_main">Home</string>
     <string name="screen_settings">Settings</string>
+    <string name="screen_history">History</string>
     <string name="scaffold_title">Léon – The URL Cleaner</string>
     <string name="share">Share</string>
     <string name="open">Open</string>
@@ -51,6 +52,14 @@
     <string name="auto_reset_after">Auto-reset after</string>
     <string name="auto_reset_off">Off</string>
     <string name="auto_reset_minutes">%1$d min</string>
+    <string name="history_enabled">Keep history of cleaned URLs</string>
+    <string name="history_empty_title">Nothing here yet</string>
+    <string name="history_empty_text">URLs you clean appear here, so you can share, copy or open them again later. The last ten are kept.</string>
+    <string name="history_disabled_text">The history is turned off. Turn it on in the settings to keep the last ten cleaned URLs.</string>
+    <string name="history_clear_all">Clear history</string>
+    <string name="history_clear_all_confirm">Remove all entries from the history?</string>
+    <string name="history_delete">Delete</string>
+    <string name="cancel">Cancel</string>
     <string name="process_text_action_name">Clean URL (Léon)</string>
     <string name="protect_screen">Protect app screen</string>
     <string name="about">About</string>

--- a/app/src/test/kotlin/com/svenjacobs/app/leon/ui/screens/main/model/MainScreenViewModelTest.kt
+++ b/app/src/test/kotlin/com/svenjacobs/app/leon/ui/screens/main/model/MainScreenViewModelTest.kt
@@ -29,6 +29,7 @@ import com.svenjacobs.app.leon.core.domain.sanitizer.catalog.GoogleAnalytics
 import com.svenjacobs.app.leon.core.domain.sanitizer.catalog.GoogleSearch
 import com.svenjacobs.app.leon.core.domain.url.Url
 import com.svenjacobs.app.leon.datastore.AppDataStoreManager
+import com.svenjacobs.app.leon.db.HistoryDao
 import com.svenjacobs.app.leon.ui.model.AutoReset
 import com.svenjacobs.app.leon.ui.screens.main.model.MainScreenViewModel.UiState.Result
 import io.kotest.core.spec.style.WordSpec
@@ -39,6 +40,7 @@ import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.Runs
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -58,19 +60,35 @@ class MainScreenViewModelTest :
     WordSpec({
         lateinit var viewModel: MainScreenViewModel
 
+        /**
+         * A mocked [AppDataStoreManager] with every flow defaulted, so a test overrides only what
+         * it needs.
+         */
+        fun appDataStoreManager(
+            autoReset: AutoReset = AutoReset.Off,
+            lastInput: AppDataStoreManager.LastInput? = null,
+            actionAfterClean: ActionAfterClean = ActionAfterClean.DoNothing,
+            historyEnabled: Boolean = true,
+        ): AppDataStoreManager = mockk {
+            every { urlDecodeEnabled } returns flowOf(false)
+            every { extractUrlEnabled } returns flowOf(false)
+            every { customTabsEnabled } returns flowOf(false)
+            every { this@mockk.actionAfterClean } returns flowOf(actionAfterClean)
+            every { this@mockk.autoReset } returns flowOf(autoReset)
+            every { this@mockk.lastInput } returns flowOf(lastInput)
+            every { this@mockk.historyEnabled } returns flowOf(historyEnabled)
+            coEvery { setLastInput(any(), any()) } just Runs
+        }
+
+        fun historyDao(): HistoryDao = mockk {
+            coEvery { record(any(), any(), any(), any()) } just Runs
+        }
+
         beforeEach {
             Dispatchers.setMain(UnconfinedTestDispatcher())
 
             val appDataStoreManager =
-                mockk<AppDataStoreManager> {
-                    every { urlDecodeEnabled } returns flowOf(false)
-                    every { extractUrlEnabled } returns flowOf(false)
-                    every { customTabsEnabled } returns flowOf(false)
-                    every { actionAfterClean } returns flowOf(ActionAfterClean.OpenShareMenu)
-                    every { autoReset } returns flowOf(AutoReset.Off)
-                    every { lastInput } returns flowOf(null)
-                    coEvery { setLastInput(any(), any()) } just Runs
-                }
+                appDataStoreManager(actionAfterClean = ActionAfterClean.OpenShareMenu)
 
             val cleaner =
                 mockk<Cleaner> {
@@ -95,23 +113,18 @@ class MainScreenViewModelTest :
                 }
 
             viewModel =
-                MainScreenViewModel(appDataStoreManager = appDataStoreManager, cleaner = cleaner)
+                MainScreenViewModel(
+                    appDataStoreManager = appDataStoreManager,
+                    cleaner = cleaner,
+                    historyDao = historyDao(),
+                )
         }
 
         afterEach { Dispatchers.resetMain() }
 
         "onChangeToggled" should
             {
-                fun dataStore() =
-                    mockk<AppDataStoreManager> {
-                        every { urlDecodeEnabled } returns flowOf(false)
-                        every { extractUrlEnabled } returns flowOf(false)
-                        every { customTabsEnabled } returns flowOf(false)
-                        every { actionAfterClean } returns flowOf(ActionAfterClean.DoNothing)
-                        every { autoReset } returns flowOf(AutoReset.Off)
-                        every { lastInput } returns flowOf(null)
-                        coEvery { setLastInput(any(), any()) } just Runs
-                    }
+                fun dataStore() = appDataStoreManager()
 
                 /** A view model on a real [Cleaner], so that changes are actually proposed. */
                 fun realViewModel(): MainScreenViewModel {
@@ -119,22 +132,13 @@ class MainScreenViewModelTest :
                         mockk<SanitizerRepository> { coEvery { isEnabled(any()) } returns true }
 
                     return MainScreenViewModel(
-                        appDataStoreManager =
-                            mockk<AppDataStoreManager> {
-                                every { urlDecodeEnabled } returns flowOf(false)
-                                every { extractUrlEnabled } returns flowOf(false)
-                                every { customTabsEnabled } returns flowOf(false)
-                                every { actionAfterClean } returns
-                                    flowOf(ActionAfterClean.DoNothing)
-                                every { autoReset } returns flowOf(AutoReset.Off)
-                                every { lastInput } returns flowOf(null)
-                                coEvery { setLastInput(any(), any()) } just Runs
-                            },
+                        appDataStoreManager = appDataStoreManager(),
                         cleaner =
                             Cleaner(
                                 sanitizers = persistentListOf(GoogleAnalytics),
                                 repository = repository,
                             ),
+                        historyDao = historyDao(),
                     )
                 }
 
@@ -223,6 +227,7 @@ class MainScreenViewModelTest :
                                                 coEvery { isEnabled(any()) } returns true
                                             },
                                     ),
+                                historyDao = historyDao(),
                             )
                         backgroundScope.launch { viewModel.uiState.collect {} }
 
@@ -298,6 +303,7 @@ class MainScreenViewModelTest :
                                                 coEvery { isEnabled(any()) } returns true
                                             },
                                     ),
+                                historyDao = historyDao(),
                             )
                         backgroundScope.launch { viewModel.uiState.collect {} }
 
@@ -355,6 +361,7 @@ class MainScreenViewModelTest :
                                                 coEvery { isEnabled(any()) } returns true
                                             },
                                     ),
+                                historyDao = historyDao(),
                             )
                         backgroundScope.launch { viewModel.uiState.collect {} }
 
@@ -411,16 +418,7 @@ class MainScreenViewModelTest :
                 fun viewModel(autoReset: AutoReset, lastInput: AppDataStoreManager.LastInput?) =
                     MainScreenViewModel(
                         appDataStoreManager =
-                            mockk<AppDataStoreManager> {
-                                every { urlDecodeEnabled } returns flowOf(false)
-                                every { extractUrlEnabled } returns flowOf(false)
-                                every { customTabsEnabled } returns flowOf(false)
-                                every { actionAfterClean } returns
-                                    flowOf(ActionAfterClean.DoNothing)
-                                every { this@mockk.autoReset } returns flowOf(autoReset)
-                                every { this@mockk.lastInput } returns flowOf(lastInput)
-                                coEvery { setLastInput(any(), any()) } just Runs
-                            },
+                            appDataStoreManager(autoReset = autoReset, lastInput = lastInput),
                         cleaner =
                             Cleaner(
                                 sanitizers = persistentListOf(GoogleAnalytics),
@@ -429,6 +427,7 @@ class MainScreenViewModelTest :
                                         coEvery { isEnabled(any()) } returns true
                                     },
                             ),
+                        historyDao = historyDao(),
                     )
 
                 "report the deadline of an input which is still fresh" {
@@ -504,6 +503,7 @@ class MainScreenViewModelTest :
                                             flowOf(ActionAfterClean.DoNothing)
                                         every { autoReset } returns flowOf(AutoReset.OneMinute)
                                         every { this@mockk.lastInput } returns lastInput
+                                        every { historyEnabled } returns flowOf(true)
                                         coEvery { setLastInput(any(), any()) } answers
                                             {
                                                 lastInput.value =
@@ -521,6 +521,7 @@ class MainScreenViewModelTest :
                                                 coEvery { isEnabled(any()) } returns true
                                             },
                                     ),
+                                historyDao = historyDao(),
                             )
                         backgroundScope.launch { viewModel.uiState.collect {} }
 
@@ -572,6 +573,125 @@ class MainScreenViewModelTest :
                 "return true again for a new inputId, even with identical text (#775)" {
                     viewModel.consumeActionAfterClean("id-1") shouldBe true
                     viewModel.consumeActionAfterClean("id-2") shouldBe true
+                }
+            }
+
+        "history" should
+            {
+                /** A view model on a real [Cleaner], recording to [dao]. */
+                fun viewModel(dao: HistoryDao, historyEnabled: Boolean = true) =
+                    MainScreenViewModel(
+                        appDataStoreManager = appDataStoreManager(historyEnabled = historyEnabled),
+                        cleaner =
+                            Cleaner(
+                                sanitizers = persistentListOf(GoogleAnalytics),
+                                repository =
+                                    mockk<SanitizerRepository> {
+                                        coEvery { isEnabled(any()) } returns true
+                                    },
+                            ),
+                        historyDao = dao,
+                    )
+
+                "record a new input's cleaned URL exactly once" {
+                    runTest(UnconfinedTestDispatcher()) {
+                        val dao = historyDao()
+                        val viewModel = viewModel(dao)
+                        backgroundScope.launch { viewModel.uiState.collect {} }
+
+                        viewModel.setText(
+                            "https://example.com/p?utm_source=x",
+                            id = "id-1",
+                        )
+
+                        coVerify(exactly = 1) {
+                            dao.record(
+                                id = "id-1",
+                                url = "https://example.com/p",
+                                at = any(),
+                                max = any(),
+                            )
+                        }
+                    }
+                }
+
+                "record again with the new URL when a change is toggled" {
+                    runTest(UnconfinedTestDispatcher()) {
+                        val dao = historyDao()
+                        val viewModel = viewModel(dao)
+                        backgroundScope.launch { viewModel.uiState.collect {} }
+
+                        viewModel.setText(
+                            "https://example.com/p?utm_source=x",
+                            id = "id-1",
+                        )
+                        val removal =
+                            (viewModel.uiState.value.result as Result.Success).changes.first {
+                                it.sanitizerIds.isNotEmpty()
+                            }
+                        viewModel.onChangeToggled(removal, apply = false)
+
+                        coVerify(exactly = 1) {
+                            dao.record(
+                                id = "id-1",
+                                url = "https://example.com/p?utm_source=x",
+                                at = any(),
+                                max = any(),
+                            )
+                        }
+                    }
+                }
+
+                "record a second setText under a different id" {
+                    runTest(UnconfinedTestDispatcher()) {
+                        val dao = historyDao()
+                        val viewModel = viewModel(dao)
+                        backgroundScope.launch { viewModel.uiState.collect {} }
+
+                        viewModel.setText("https://example.com/a", id = "id-1")
+                        viewModel.setText("https://example.com/b", id = "id-2")
+
+                        coVerify(exactly = 1) {
+                            dao.record(
+                                id = "id-1",
+                                url = "https://example.com/a",
+                                at = any(),
+                                max = any(),
+                            )
+                        }
+                        coVerify(exactly = 1) {
+                            dao.record(
+                                id = "id-2",
+                                url = "https://example.com/b",
+                                at = any(),
+                                max = any(),
+                            )
+                        }
+                    }
+                }
+
+                "not record when history is disabled" {
+                    runTest(UnconfinedTestDispatcher()) {
+                        val dao = historyDao()
+                        val viewModel = viewModel(dao, historyEnabled = false)
+                        backgroundScope.launch { viewModel.uiState.collect {} }
+
+                        viewModel.setText("https://example.com/p?utm_source=x", id = "id-1")
+
+                        coVerify(exactly = 0) { dao.record(any(), any(), any(), any()) }
+                    }
+                }
+
+                "not record text that yields no URL" {
+                    runTest(UnconfinedTestDispatcher()) {
+                        val dao = historyDao()
+                        val viewModel = viewModel(dao)
+                        backgroundScope.launch { viewModel.uiState.collect {} }
+
+                        viewModel.setText("just some text, no link here", id = "id-1")
+
+                        coVerify(exactly = 0) { dao.record(any(), any(), any(), any()) }
+                    }
                 }
             }
     })

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,8 @@ plugins {
     alias(libs.plugins.spotless)
     alias(libs.plugins.adarshr.test.logger)
     alias(libs.plugins.aboutlibraries) apply false
+    alias(libs.plugins.ksp) apply false
+    alias(libs.plugins.room3) apply false
 }
 
 subprojects {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,9 +3,11 @@ android-gradle-plugin = "9.2.0"
 androidx-activity = "1.13.0"
 androidx-compose-bom = "2026.08.00" # https://developer.android.com/jetpack/compose/bom/bom-mapping
 androidx-lifecycle = "2.11.0"
+androidx-room3 = "3.0.2"
 kotest = "6.2.4"
 kotlin = "2.4.10"
 kotlinx-coroutines = "1.11.0"
+ksp = "2.3.11"
 mikepenz-aboutlibraries = "15.2.0"
 
 [libraries]
@@ -30,7 +32,11 @@ androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtim
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "androidx-lifecycle" }
 androidx-navigation-compose = "androidx.navigation:navigation-compose:2.10.0"
+androidx-room3-compiler = { module = "androidx.room3:room3-compiler", version.ref = "androidx-room3" }
+androidx-room3-runtime = { module = "androidx.room3:room3-runtime", version.ref = "androidx-room3" }
 androidx-startup-runtime = "androidx.startup:startup-runtime:1.2.0"
+androidx-test-ext-junit = "androidx.test.ext:junit:1.3.0"
+androidx-test-runner = "androidx.test:runner:1.7.0"
 compose-gradle-plugin = { module = "org.jetbrains.kotlin.plugin.compose:org.jetbrains.kotlin.plugin.compose.gradle.plugin", version.ref = "kotlin" }
 facebook-stetho = "com.facebook.stetho:stetho:1.6.0"
 jakewharton-timber = "com.jakewharton.timber:timber:5.0.1"
@@ -59,4 +65,6 @@ androidx-compose = [
 adarshr-test-logger = "com.adarshr.test-logger:4.0.0"
 ben-manes-versions = "com.github.ben-manes.versions:0.61.0"
 aboutlibraries = { id = "com.mikepenz.aboutlibraries.plugin.android", version.ref = "mikepenz-aboutlibraries" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+room3 = { id = "androidx.room3", version.ref = "androidx-room3" }
 spotless = "com.diffplug.spotless:8.10.1"


### PR DESCRIPTION
## TL;DR

Adds a History tab between Home and Settings that keeps the last ten cleaned URLs in a Room 3 database. Tapping an entry offers share, copy, open and delete; a button clears the lot. The feature can be switched off in the settings, which also wipes what is stored.

Closes #201

## Notable decisions

- **The session id is the primary key.** `MainActivity` already stamps a stable `EXTRA_SOURCE_TEXT_ID` on each intent — fresh per genuine share, preserved across redelivery — and `MainScreenViewModel` carries it as `inputId`. Recording is an upsert on that id, so ticking changes on and off updates the row in place instead of filling the stack, while a new share inserts. An updated row keeps its original timestamp: that says when the URL was cleaned, not when it was last edited.
- **One URL per entry**, `Result.Success.urls.first()`, not the whole cleaned text. Sharing a text with two URLs therefore records only the first. This keeps share/copy/open well-defined on a real URL; nothing is recorded when the text contained no URL.
- **`ProcessTextActivity` is not recorded.** In-place cleaning from another app's text selection has no session, no selection and shows no UI; silently recording it would be surprising.
- **The tab stays visible when the history is off**, showing an empty state that explains why, rather than disappearing from the bottom bar.
- Share/copy/open were private local functions inside `MainScreen`. They are now `ui/common/UrlActions.kt` and shared with the history screen instead of becoming a third copy — behaviour on the main screen is unchanged.

## Room 3

First database in the project, so this brings KSP with it. Note it is **Room 3** (`androidx.room3`, package `androidx.room3.*`), not Room 2: no `-ktx` artifact, KSP mandatory, and the builder takes an explicit `AndroidSQLiteDriver`. `settings.gradle.kts` gained a `pluginManagement` block because plugin resolution defaulted to the Gradle Plugin Portal, which does not host `androidx.room3`. The generated schema is committed.

## Testing

1. Share `https://www.example.com/p?utm_source=x&keep=1` with Léon → the History tab shows the cleaned URL with today's date and time.
2. On Home, untick a change so the cleaned URL changes → the entry is **updated in place**, not duplicated, and keeps the timestamp from step 1.
3. Share a different URL → a second entry appears **above** the first.
4. Share eleven URLs → ten remain, the oldest gone.
5. Tap an entry → share, copy and open behave as the buttons on Home do; delete removes just that entry. With Léon set as the default browser, Open is disabled.
6. "Clear history" → confirmation dialog → the list empties and the empty state appears.
7. Settings → turn the history off: the tab stays, the screen explains it is off, the entries are gone. Turn it back on → still empty, and a fresh share is recorded again.
8. Kill and relaunch the app → the history survives.
9. Clean text via another app's text selection menu ("Clean URL (Léon)") → nothing is recorded.

```bash
./gradlew :app:test :core-domain:test
./gradlew spotlessCheck
```

`MainScreenViewModelTest` gained a `history` block covering what the ViewModel decides: records once per input, re-records on a toggle, records under a new id for a new share, and records nothing when the setting is off or when the text yields no URL.

`app/src/androidTest/.../HistoryDaoTest.kt` covers the SQL that the ViewModel test cannot — the ten-entry cap and the update-vs-insert branch — against an in-memory database. **It does not run in CI**: `.github/workflows/build.yml` has no emulator job and the project had no instrumented tests before this. It compiles, and runs locally with `./gradlew :app:connectedDebugAndroidTest`. Manual steps 2–4 cover the same ground. Happy to drop the file if the emulator setup is not wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)