### PR TITLE
docs: correct the minSdk in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-**Léon – The URL Cleaner** is an Android application (minSdk 23, Kotlin) that removes tracking
+**Léon – The URL Cleaner** is an Android application (minSdk 24, Kotlin) that removes tracking
 and other unwanted parameters from URLs before sharing. It integrates into Android's standard
 sharing mechanism and is also meant as a blueprint for modern Android development.
 


### PR DESCRIPTION
## TL;DR

The project overview still said minSdk 23. It moved to 24 in #806.

`CLAUDE.md` and `.github/copilot-instructions.md` are symlinks to `AGENTS.md`, so this one line covers all three.