### PR TITLE
fix(cleaner): keep the URL structure intact when decoding

### DIFF
--- a/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/Cleaner.kt
+++ b/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/Cleaner.kt
@@ -102,7 +102,9 @@ class Cleaner(
             originalText = input,
             cleanedText =
                 if (decodeUrl) {
-                    withContext(Dispatchers.Default) { decodeUrl(cleanedText) }
+                    withContext(Dispatchers.Default) {
+                        decodeUrl(cleanedText, keepStructure = true)
+                    }
                 } else {
                     cleanedText
                 },

--- a/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/url/DecodeUrl.kt
+++ b/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/url/DecodeUrl.kt
@@ -24,8 +24,16 @@ package com.svenjacobs.app.leon.core.domain.url
  * `%` which is not followed by two hexadecimal digits is kept as it is instead of throwing, because
  * a URL somebody shares is not necessarily well formed and is better returned unchanged than not at
  * all.
+ *
+ * @param keepStructure When `true`, an escape whose decoded byte is a delimiter the URL syntax
+ *   relies on — `/ ? # & = : + %`, space, or any other byte below `0x21` — is left in its original
+ *   spelling (e.g. `%2f` stays `%2f`, not `/`) instead of being decoded, and a literal `+` stays a
+ *   literal `+` instead of becoming a space. Decoding those would change what the URL addresses
+ *   (`%2F` inside a path segment turning into a `/` that splits it) rather than merely how it is
+ *   displayed, which is what this is for: showing a human-readable URL (`%C3%BC` → `ü`) without
+ *   rewriting its structure.
  */
-fun decodeUrl(encoded: String): String {
+fun decodeUrl(encoded: String, keepStructure: Boolean = false): String {
     if ('%' !in encoded && '+' !in encoded) return encoded
 
     val bytes = ArrayList<Byte>(encoded.length)
@@ -34,7 +42,7 @@ fun decodeUrl(encoded: String): String {
     while (i < encoded.length) {
         when (val char = encoded[i]) {
             '+' -> {
-                bytes += ' '.code.toByte()
+                bytes += if (keepStructure) '+'.code.toByte() else ' '.code.toByte()
                 i++
             }
             '%' -> {
@@ -42,6 +50,10 @@ fun decodeUrl(encoded: String): String {
                 if (byte == null) {
                     bytes += char.code.toByte()
                     i++
+                } else if (keepStructure && byte.isStructural()) {
+                    // Original spelling, not the decoded byte, so `%2f` does not become `%2F`.
+                    encoded.substring(i, i + 3).encodeToByteArray().forEach { bytes += it }
+                    i += 3
                 } else {
                     bytes += byte
                     i += 3
@@ -64,3 +76,9 @@ private fun String.hexByteAt(index: Int): Byte? {
     val low = this[index + 1].digitToIntOrNull(radix = 16) ?: return null
     return ((high shl 4) or low).toByte()
 }
+
+/** The ASCII delimiters and control characters a URL's syntax depends on. */
+private val STRUCTURAL_BYTES = "/?#&=:+%".map { it.code.toByte() }.toSet()
+
+/** Whether decoding this byte would change what a URL addresses rather than just how it reads. */
+private fun Byte.isStructural(): Boolean = (toInt() and 0xFF) < 0x21 || this in STRUCTURAL_BYTES

--- a/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/CleanerTest.kt
+++ b/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/CleanerTest.kt
@@ -109,7 +109,17 @@ class CleanerTest :
                             decodeUrl = true,
                         )
 
-                    result.cleanedText shouldBe "https://www.some.site/Hello/World"
+                    result.cleanedText shouldBe "https://www.some.site/Hello%2FWorld"
+                }
+
+                "URL decode keeps %20 intact but decodes UTF-8 text" {
+                    val result =
+                        service.clean(
+                            text = "https://www.some.site/?q=Hello%20M%C3%BCnchen&paramA=A",
+                            decodeUrl = true,
+                        )
+
+                    result.cleanedText shouldBe "https://www.some.site/?q=Hello%20München"
                 }
 
                 "repeat cleaning until iteration doesn't yield new value" {

--- a/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/url/DecodeUrlTest.kt
+++ b/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/url/DecodeUrlTest.kt
@@ -1,0 +1,99 @@
+/*
+ * Léon - The URL Cleaner
+ * Copyright (C) 2026 Sven Jacobs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.svenjacobs.app.leon.core.domain.url
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+
+class DecodeUrlTest :
+    WordSpec({
+        "decodeUrl" should
+            {
+                "decode UTF-8 multi-byte sequences without keepStructure" {
+                    decodeUrl("M%C3%BCnchen") shouldBe "München"
+                }
+
+                "decode UTF-8 multi-byte sequences with keepStructure" {
+                    decodeUrl("M%C3%BCnchen", keepStructure = true) shouldBe "München"
+                }
+
+                "decode + as space without keepStructure" {
+                    decodeUrl("Hello+World") shouldBe "Hello World"
+                }
+
+                "keep a literal + as + with keepStructure" {
+                    decodeUrl("Hello+World", keepStructure = true) shouldBe "Hello+World"
+                }
+
+                "decode %20 as space without keepStructure" {
+                    decodeUrl("Hello%20World") shouldBe "Hello World"
+                }
+
+                "keep %20 as %20 with keepStructure" {
+                    decodeUrl("Hello%20World", keepStructure = true) shouldBe "Hello%20World"
+                }
+
+                "decode %2F without keepStructure" {
+                    decodeUrl("Hello%2FWorld") shouldBe "Hello/World"
+                }
+
+                "keep %2F as %2F with keepStructure" {
+                    decodeUrl("Hello%2FWorld", keepStructure = true) shouldBe "Hello%2FWorld"
+                }
+
+                "keep %26 as %26 with keepStructure" {
+                    decodeUrl("a%26b", keepStructure = true) shouldBe "a%26b"
+                }
+
+                "keep %3F as %3F with keepStructure" {
+                    decodeUrl("a%3Fb", keepStructure = true) shouldBe "a%3Fb"
+                }
+
+                "keep %23 as %23 with keepStructure" {
+                    decodeUrl("a%23b", keepStructure = true) shouldBe "a%23b"
+                }
+
+                "keep %25 as %25 with keepStructure" {
+                    decodeUrl("a%25b", keepStructure = true) shouldBe "a%25b"
+                }
+
+                "keep %3D as %3D with keepStructure" {
+                    decodeUrl("a%3Db", keepStructure = true) shouldBe "a%3Db"
+                }
+
+                "keep %3A as %3A with keepStructure" {
+                    decodeUrl("a%3Ab", keepStructure = true) shouldBe "a%3Ab"
+                }
+
+                "preserve the original escape casing with keepStructure" {
+                    decodeUrl("a%2fb%2Fc", keepStructure = true) shouldBe "a%2fb%2Fc"
+                }
+
+                "return a malformed trailing % unchanged without keepStructure" {
+                    decodeUrl("100%") shouldBe "100%"
+                }
+
+                "return a malformed trailing % unchanged with keepStructure" {
+                    decodeUrl("100%", keepStructure = true) shouldBe "100%"
+                }
+
+                "return text without escapes unchanged" {
+                    decodeUrl("plain-text") shouldBe "plain-text"
+                }
+            }
+    })


### PR DESCRIPTION
## TL;DR

"Decode URL" decoded every percent-escape in the whole cleaned text, including the ones that define the URL's structure (`%2F`, `%26`, `%3F`, `%20`, `+`, …), which could turn a path segment into an extra `/` or otherwise change what the URL addresses. `decodeUrl()` now takes a `keepStructure` flag that leaves those structural escapes in their original spelling while still decoding everything else, such as UTF-8 text; the display path in `Cleaner.clean()` now passes `keepStructure = true`, while the redirect-unwrapping `Decode.PercentDecode` step (which needs `%3A%2F%2F` to become `://`) is untouched.

## Testing

1. Share `https://www.some.site/?q=Hello%20M%C3%BCnchen` with Léon and enable "Decode URL" in settings.
2. The result should read `https://www.some.site/?q=Hello%20München` — `%20` stays intact, `M%C3%BC` decodes to `Mü`.
3. Run `./gradlew :core-domain:test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)