### PR TITLE
fix(sanitizer): remove Instagram "stkn" tracking parameter

### DIFF
--- a/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/catalog/Instagram.kt
+++ b/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/catalog/Instagram.kt
@@ -28,6 +28,6 @@ val Instagram =
     Sanitizer(
         id = SanitizerId("instagram"),
         name = "Instagram",
-        rules = persistentListOf(Rule.RemoveParameters("igsh|igsi")),
+        rules = persistentListOf(Rule.RemoveParameters("igsh|igsi|stkn")),
         match = persistentListOf(Match(HostMatch.Domain("instagram.com"))),
     )

--- a/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/instagram/InstagramTest.kt
+++ b/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/instagram/InstagramTest.kt
@@ -41,6 +41,13 @@ class InstagramTest :
                         result shouldBe "https://www.instagram.com/reel/Ceeg-VgI4yF/"
                     }
 
+                    "remove \"stkn\" parameter" {
+                        val result =
+                            clean("https://www.instagram.com/reel/Ceeg-VgI4yF/?stkn=YmMyMTA2M2Y=")
+
+                        result shouldBe "https://www.instagram.com/reel/Ceeg-VgI4yF/"
+                    }
+
                     "keep other parameters" {
                         val result =
                             clean("https://www.instagram.com/p/Ceeg-VgI4yF/?igsi=abc&img_index=2")


### PR DESCRIPTION
## TL;DR

Instagram added a new tracking parameter, `stkn`. This extends the Instagram sanitizer's regex to also remove it, alongside the existing `igsh`/`igsi` parameters.

## Testing

1. Share `https://www.instagram.com/reel/Ceeg-VgI4yF/?stkn=YmMyMTA2M2Y=` with Léon.
2. The cleaned URL must no longer contain `stkn`.
3. Run `./gradlew :core-domain:test`.

Closes #829

🤖 Generated with [Claude Code](https://claude.com/claude-code)