### PR TITLE
fix(desktop): open URLs when Desktop.Action.BROWSE is unsupported

### DIFF
--- a/shared/src/desktopMain/kotlin/com/svenjacobs/app/leon/ui/common/UrlActions.desktop.kt
+++ b/shared/src/desktopMain/kotlin/com/svenjacobs/app/leon/ui/common/UrlActions.desktop.kt
@@ -30,10 +30,23 @@ private object DesktopUrlActions : UrlActions {
     override fun share(text: String, chooserTitle: String) {}
 
     override fun open(url: String, customTabs: Boolean, chooserTitle: String) {
-        if (!Desktop.isDesktopSupported()) return
-        val desktop = Desktop.getDesktop()
-        if (!desktop.isSupported(Desktop.Action.BROWSE)) return
-        runCatching { desktop.browse(URI(url)) }
+        val browsed =
+            Desktop.isDesktopSupported() &&
+                Desktop.getDesktop().isSupported(Desktop.Action.BROWSE) &&
+                runCatching { Desktop.getDesktop().browse(URI(url)) }.isSuccess
+
+        // Desktop.Action.BROWSE is unsupported on most Linux desktops (the JDK reaches for gio,
+        // which frequently isn't resolvable), so fall back to the platform's own URL opener.
+        if (!browsed) {
+            val os = System.getProperty("os.name").orEmpty().lowercase()
+            val command =
+                when {
+                    os.contains("mac") -> listOf("open", url)
+                    os.contains("win") -> listOf("rundll32", "url.dll,FileProtocolHandler", url)
+                    else -> listOf("xdg-open", url)
+                }
+            runCatching { ProcessBuilder(command).start() }
+        }
     }
 }
 


### PR DESCRIPTION
## TL;DR

The Open button did nothing on Linux: `Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)` returns `false` on Fedora (the JDK reaches for gio, which frequently isn't resolvable), so `DesktopUrlActions.open` returned early without doing anything. It now falls back to the platform's own URL opener — `xdg-open`, `open` on macOS, `rundll32 url.dll,FileProtocolHandler` on Windows.

## Testing

1. Install the RPM or run the AppImage on Linux (or `./gradlew :desktopApp:run`).
2. Clean a URL and press **Open** — the default browser must open it.
3. Same on the History and Settings screens, which use the same `UrlActions.open`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
