### PR TITLE
chore(ci): parallelize the deploy workflow and tighten permissions

### DIFF
--- a/.github/actions/reveal-secrets/action.yml
+++ b/.github/actions/reveal-secrets/action.yml
@@ -1,0 +1,22 @@
+name: Reveal secrets
+description: Imports the GPG key and decrypts the git-secret files (keystore, signing properties, Play Store service account).
+
+inputs:
+  gpg-private-key:
+    description: The GPG private key which the git-secret files are encrypted for.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Import GPG key for git-secret
+      shell: bash
+      run: echo "${{ inputs.gpg-private-key }}" | gpg --import --batch --yes
+
+    - name: Install git-secret
+      shell: bash
+      run: sudo apt-get install git-secret
+
+    - name: Decrypt secrets
+      shell: bash
+      run: git secret reveal -f

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,17 +2,25 @@ name: Build & Verify
 
 on: [ pull_request, workflow_dispatch ]
 
+# Every job gets read-only unless it says otherwise below.
 permissions:
-  pull-requests: write
+  contents: read
+
+# A new push to a pull request makes the run for the previous commit pointless.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
     timeout-minutes: 30
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write # Comments the artifact link on the pull request.
     steps:
       - uses: actions/checkout@v7
         with:
-          fetch-depth: 0
           show-progress: false
 
       - uses: actions/setup-java@v6
@@ -54,4 +62,6 @@ jobs:
             })
 
   package-desktop:
+    permissions:
+      contents: read
     uses: ./.github/workflows/package-desktop.yml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,21 +6,26 @@ on:
       - v*
   workflow_dispatch:
 
+# Every job gets read-only unless it says otherwise below. Only the two jobs that write to
+# this repository - the release and the version bump - get contents: write; the jobs holding
+# the signing keystore and the Play Store service account do not.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   package-desktop:
+    permissions:
+      contents: read
     uses: ./.github/workflows/package-desktop.yml
 
-  deploy:
+  build-android:
     timeout-minutes: 30
     runs-on: ubuntu-latest
-    needs: package-desktop
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v7
         with:
-          fetch-depth: 0
           show-progress: false
 
       - uses: actions/setup-java@v6
@@ -38,23 +43,69 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
+      # Reveals the upload keystore and signing.properties.
+      - uses: ./.github/actions/reveal-secrets
+        with:
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+
+      - name: Build release APK & AAB
+        run: ./gradlew assembleRelease bundleRelease
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: Android artifacts
+          path: |
+            androidApp/build/outputs/apk/**/*.apk
+            androidApp/build/outputs/bundle/**/*.aab
+
+  play-store:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    needs: build-android
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          show-progress: false
+
       - name: Setup Ruby & Fastlane
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3'
           bundler-cache: true
 
-      - name: Import GPG key for git-secret
-        run: echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --import --batch --yes
+      # Reveals google-play-service-account.json.
+      - uses: ./.github/actions/reveal-secrets
+        with:
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
 
-      - name: Install git-secret
-        run: sudo apt-get install git-secret
-
-      - name: Decrypt secrets
-        run: git secret reveal -f
+      - uses: actions/download-artifact@v7
+        with:
+          name: Android artifacts
+          path: androidApp/build/outputs
 
       - name: Deploy production version
         run: bundle exec fastlane deploy
+        env:
+          # The AAB comes from the build-android job, so the lane must not rebuild it.
+          SKIP_GRADLE_BUILD: 'true'
+
+  github-release:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    needs: [build-android, package-desktop]
+    permissions:
+      contents: write # Creates the GitHub release.
+      pull-requests: read # The changelog builder reads the merged pull requests and their labels.
+    steps:
+      # The only job that needs full history: the changelog builder resolves the previous tag.
+      # The build itself does not - versionCode/versionName are literals in build.gradle.kts
+      # since 10797c9 replaced latestTagName() with a hardcoded value.
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          show-progress: false
 
       - name: Build changelog
         id: github_release
@@ -101,26 +152,26 @@ jobs:
           merge-multiple: true
           path: desktop-artifacts
 
+      - uses: actions/download-artifact@v7
+        with:
+          name: Android artifacts
+          path: android-artifacts
+
       - name: Create GitHub release
         uses: softprops/action-gh-release@v3
         with:
           body: ${{steps.github_release.outputs.changelog}}
           files: |
-            androidApp/build/outputs/apk/**/*.apk
-            androidApp/build/outputs/bundle/**/*.aab
+            android-artifacts/**/*.apk
+            android-artifacts/**/*.aab
             desktop-artifacts/**
-
-      - uses: actions/upload-artifact@v7
-        with:
-          name: Android artifacts
-          path: |
-            androidApp/build/outputs/apk/**/*.apk
-            androidApp/build/outputs/bundle/**/*.aab
 
   increment-version:
     timeout-minutes: 30
     runs-on: ubuntu-latest
-    needs: deploy
+    needs: [play-store, github-release]
+    permissions:
+      contents: write # Commits the incremented version to main.
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/package-desktop.yml
+++ b/.github/workflows/package-desktop.yml
@@ -27,7 +27,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          fetch-depth: 0
           show-progress: false
 
       - uses: actions/setup-java@v6

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -166,15 +166,27 @@ Commit the resulting `Gemfile.lock`. Watch two blocks in the diff:
 ## Releasing
 
 Releases are automated. Pushing a `v*` tag triggers
-[`.github/workflows/deploy.yml`](.github/workflows/deploy.yml), which decrypts the secrets and runs
+[`.github/workflows/deploy.yml`](.github/workflows/deploy.yml), whose jobs run like this:
+
+```
+package-desktop ─┐
+build-android ─┬─┴─> github-release ─┐
+               └───> play-store ─────┴─> increment-version
+```
+
+`build-android` decrypts the signing secrets and runs `assembleRelease bundleRelease`, in parallel
+with the desktop matrix. `play-store` picks up the resulting AAB and runs
 
 ```bash
 bundle exec fastlane deploy
 ```
 
-That lane reads `versionCode` out of `androidApp/build.gradle.kts`, builds `assembleRelease` and
-`bundleRelease`, and uploads the AAB to the **production** track as a completed release, together
-with the store listing screenshots.
+That lane reads `versionCode` out of `androidApp/build.gradle.kts` and uploads the AAB to the
+**production** track as a completed release, together with the store listing screenshots. It builds
+the AAB itself when run locally; on CI, `SKIP_GRADLE_BUILD=true` tells it to use the one
+`build-android` already produced.
+
+The GitHub release does not wait for the Play Store upload — it needs only the two artifact jobs.
 
 The lane deliberately skips metadata, changelogs and the icon/feature graphic
 (`skip_upload_metadata`, `skip_upload_changelogs`, `skip_upload_images`); those are maintained in

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -9,7 +9,8 @@ platform :android do
     UI.user_error!("Could not extract versionCode") if version_code.nil?
     UI.message("Using version code #{version_code}")
 
-    gradle(task: "assembleRelease bundleRelease")
+    # CI builds the AAB in a separate job and downloads it into androidApp/build/outputs.
+    gradle(task: "assembleRelease bundleRelease") unless ENV["SKIP_GRADLE_BUILD"]
     upload_to_play_store(
         track: 'production',
         release_status: 'completed',


### PR DESCRIPTION
## TL;DR

Splits the monolithic `deploy` job into `build-android`, `play-store` and `github-release`, so the
Android build runs alongside the desktop matrix and the GitHub release no longer waits for the Play
Store upload. Also tightens the `GITHUB_TOKEN` permissions and removes a `fetch-depth: 0` that has
been dead since 2022.

```
package-desktop ─┐
build-android ─┬─┴─> github-release ─┐
               └───> play-store ─────┴─> increment-version
```

## Notable decisions

**Handing the AAB between jobs.** `build-android` uploads the `Android artifacts` artifact;
`play-store` downloads it back into `androidApp/build/outputs` and sets `SKIP_GRADLE_BUILD=true`,
which makes the Fastlane lane skip its `gradle` call. Running `bundle exec fastlane deploy` locally
still builds the AAB itself.

**Permissions.** `contents: write` used to apply to all five jobs. It is now scoped to the two that
actually write to this repository — the jobs holding the signing keystore and the Play Store service
account are read-only. In `build.yml`, `pull-requests: write` moved off the 3-OS desktop matrix and
onto the job that comments. Both workflows also gained the `contents: read` they were relying on
implicitly: with a `permissions` block present, unlisted scopes are `none`, so `actions/checkout`
only succeeded because this repository is public.

**`fetch-depth: 0`.** Reintroduced in `adc7034` for `versionName = latestTagName()`, which
`10797c9` ("fix: Fix build issue on F-Droid") replaced with a literal five days later. Nothing in
the Gradle build has read git history since. Kept on `github-release`, where the changelog builder
resolves the previous tag.

**Concurrency.** A new push to a PR now cancels the previous run instead of paying for a full build
plus a 3-OS desktop matrix nobody will read.

## Testing

The deploy path only runs on a `v*` tag, so it cannot be verified before merge. What can be checked
on this PR:

1. `build.yml` passes, and the artifact-link comment still appears (proves `pull-requests: write`
   survived the move to job level).
2. The desktop matrix still produces all five packages.
3. Pushing a second commit cancels the first run.

On the next release tag, watch that `github-release` completes without waiting for `play-store`,
and that the release carries the APK, AAB and all desktop artifacts.